### PR TITLE
Split tutorials

### DIFF
--- a/js/modules.js
+++ b/js/modules.js
@@ -26,7 +26,16 @@ app.modules = {
       'progress': 'progress indicators',
       'fab': 'floating action button material',
       'speed-dial': 'speed dial',
-      'ripple': 'ripple effect'
+      'ripple': 'ripple effect',
+      'alert-dialog': 'alert dialog',
+      'back-button': 'back button',
+      'checkbox': 'checkbox',
+      'notification': 'notification',
+      'progress-circular': 'progress circular',
+      'radio': 'radio',
+      'search-input': 'search input',
+      'toast': 'toast',
+      'toolbar': 'toolbar'
     },
     'common patterns': {
       'kitchensink': 'kitchensink example',
@@ -75,7 +84,16 @@ app.modules = {
       'progress': 'progress indicators',
       'fab': 'floating action button material',
       'speed-dial': 'speed dial',
-      'ripple': 'ripple effect'
+      'ripple': 'ripple effect',
+      'alert-dialog': 'alert dialog',
+      'back-button': 'back button',
+      'checkbox': 'checkbox',
+      'notification': 'notification',
+      'progress-circular': 'progress circular',
+      'radio': 'radio',
+      'search-input': 'search input',
+      'toast': 'toast',
+      'toolbar': 'toolbar'
     },
     'common patterns': {
       'splitter_navigator': 'splitter outside navigator',
@@ -106,7 +124,16 @@ app.modules = {
       'progress': 'progress indicators',
       'fab': 'floating action button material',
       'speed-dial': 'speed dial',
-      'ripple': 'ripple effect'
+      'ripple': 'ripple effect',
+      'alert-dialog': 'alert dialog',
+      'back-button': 'back button',
+      'checkbox': 'checkbox',
+      'notification': 'notification',
+      'progress-circular': 'progress circular',
+      'radio': 'radio',
+      'search-input': 'search input',
+      'toast': 'toast',
+      'toolbar': 'toolbar'
     },
     'common patterns': {
       'splitter_navigator': 'splitter outside navigator',
@@ -141,7 +168,16 @@ app.modules = {
       'progress': 'progress indicators',
       'fab': 'floating action button material',
       'speed-dial': 'speed dial',
-      'ripple': 'ripple effect'
+      'ripple': 'ripple effect',
+      'alert-dialog': 'alert dialog',
+      'back-button': 'back button',
+      'checkbox': 'checkbox',
+      'notification': 'notification',
+      'progress-circular': 'progress circular',
+      'radio': 'radio',
+      'search-input': 'search input',
+      'toast': 'toast',
+      'toolbar': 'toolbar'
     },
     'common patterns': {
       'splitter_navigator': 'splitter outside navigator',
@@ -173,7 +209,16 @@ app.modules = {
       'progress': 'progress indicators',
       'fab': 'floating action button material',
       'speed-dial': 'speed dial',
-      'ripple': 'ripple effect'
+      'ripple': 'ripple effect',
+      'alert-dialog': 'alert dialog',
+      'back-button': 'back button',
+      'checkbox': 'checkbox',
+      'notification': 'notification',
+      'progress-circular': 'progress circular',
+      'radio': 'radio',
+      'search-input': 'search input',
+      'toast': 'toast',
+      'toolbar': 'toolbar'
     },
     'common patterns': {
       'splitter_navigator': 'splitter outside navigator',

--- a/tutorial/angular1/reference/alert-dialog.html
+++ b/tutorial/angular1/reference/alert-dialog.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+      .controller('PageController', function($scope) {
+        this.showDialog = function() {
+          if (this.dialog) {
+            this.dialog.show();
+          } else {
+            ons.createDialog('dialog.html', { parentScope: $scope })
+              .then(function(dialog) {
+                this.dialog = dialog;
+                dialog.show();
+              }.bind(this));
+          }
+        }.bind(this);
+      });
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page">
+    <ons-toolbar>
+      <div class="center">Dialogs</div>
+    </ons-toolbar>
+
+    <ons-list>
+      <ons-list-header>Showing dialogs</ons-list-header>
+      <ons-list-item tappable ng-click="dialog.show()">Simple dialog</ons-list-item>
+      <ons-list-item tappable ng-click="alertDialog.show()">Alert dialog</ons-list-item>
+      <ons-list-item tappable ng-click="page.showDialog()">From template</ons-list-item>
+      <ons-list-item tappable ng-click="toast.toggle()">Toggle toast</ons-list-item>
+      <ons-list-header>Notifications</ons-list-header>
+      <ons-list-item tappable ng-click="ons.notification.alert('Hello, world')">Alert</ons-list-item>
+      <ons-list-item tappable ng-click="ons.notification.confirm({message: 'Are you ready?'})">Confirmation</ons-list-item>
+      <ons-list-item tappable ng-click="ons.notification.prompt({message: 'What is your name?'})">Prompt</ons-list-item>
+    </ons-list>
+  </ons-page>
+
+  <ons-dialog var="dialog">
+    <div style="text-align: center; padding: 10px;">
+      <p>
+        This is a dialog.
+      </p>
+
+      <p>
+        <ons-button ng-click="dialog.hide()">Close</ons-button>
+      </p>
+    </div>
+  </ons-dialog>
+
+  <ons-alert-dialog var="alertDialog">
+    <div class="alert-dialog-title">Warning!</div>
+    <div class="alert-dialog-content">
+      An error has occurred!
+    </div>
+    <div class="alert-dialog-footer">
+      <button class="alert-dialog-button" ng-click="alertDialog.hide()">Cancel</button>
+      <button class="alert-dialog-button" ng-click="alertDialog.hide()">OK</button>
+    </div>
+  </ons-alert-dialog>
+
+  <template id="dialog.html">
+    <ons-dialog id="dialog-3">
+      <div style="text-align: center; padding: 10px;">
+        <p>
+          This dialog was created from a template.
+        <p>
+
+        <p>
+          <ons-button ng-click="page.dialog.hide()">Close</ons-button>
+        </p>
+      </div>
+    </ons-dialog>
+  </template>
+
+  <ons-toast var="toast">
+    This is an Onsen Toast!<button>Hoge</button>
+  </ons-toast>
+</body>
+</html>
+
+<!-- info
+
+## Dialogs
+
+Dialogs are defined using the `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` tags.
+
+```
+<ons-dialog var="dialog">
+  This is a dialog!
+</ons-dialog>
+```
+
+`var` attribute is used to store the dialog in a variable for later access.
+
+Alert dialogs work exactly like normal dialogs but they require some additional markup. With this element you can create a beautifully styled dialog without any additional CSS.
+
+```
+<ons-alert-dialog>
+  <div class="alert-dialog-title">Warning!</div>
+  <div class="alert-dialog-content">
+    An error has occurred!
+  </div>
+  <div class="alert-dialog-footer">
+    <button class="alert-dialog-button">Cancel</button>
+    <button class="alert-dialog-button">OK</button>
+  </div>
+</ons-alert-dialog>
+```
+
+Dialogs are hidden by default and usually attached as direct children of the `<body>` tag.
+
+## Displaying a dialog
+
+To display a dialog you need to get a reference to the element and execute the `show(options)` method.
+It is hidden with the `hide(options)` method.
+
+## Loading from a template
+
+Another way to use dialogs is with the `ons.createDialog(template)` utility function. The dialog needs to be defined as a template and the function returns a `Promise` that resolves to the dialog element.
+
+```
+<template id="dialog.html">
+  <ons-dialog>
+    This dialog is defined as a template.
+  </ons-dialog>
+</template>
+```
+
+```
+ons
+  .createDialog('dialog.html')
+  .then(function(dialog) {
+    dialog.show();
+  });
+```
+
+For AngularJS, an extra parameter can be passed to specify the scope of the new popover: `ons.createDialog('dialog.html', { parentScope: $scope });`
+
+## The `cancelable` attribute
+
+The `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` support the `cancelable` attribute. This enables hiding the dialog by tapping outside of it or by pressing the back button on Android devices.
+
+```
+<ons-dialog cancelable>
+  This dialog can be cancelled!
+</ons-dialog>
+```
+
+Try adding the `cancelable` attribute to one of the dialogs to see how it works.
+
+## Notification
+
+Another way to display dialogs is with the `ons.notification` methods:
+
+* `ons.notification.alert(options)`
+* `ons.notification.confirm(options)`
+* `ons.notification.prompt(options)`
+* `ons.notification.toast(options)`
+
+These methods all return a `Promise`. For the `confirm` it resolves to the index of the button pressed and for the `prompt` it resolves to the user input.
+
+```
+ons
+  .notification.prompt({message: 'What is your name?'})
+  .then(function(name) {
+    ons.notification.alert('Hello ' + name);
+  });
+```
+
+
+-->

--- a/tutorial/angular1/reference/back-button.html
+++ b/tutorial/angular1/reference/back-button.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+      .controller('Page2Controller', function($scope) {
+        console.log('controller', $scope.myNavigator.topPage.data);
+
+        this.init = function(e) {
+          // Ensure the emitter is the current page, not a nested one
+          if (e.target === e.currentTarget) {
+            var page = e.target;
+            // Safely access data
+            console.log('init event', page.data);
+          }
+        };
+      });
+  </script>
+</head>
+<body>
+  <ons-navigator swipeable var="myNavigator" page="page1.html"></ons-navigator>
+
+  <template id="page1.html">
+    <ons-page>
+      <ons-toolbar>
+        <div class="center">Page 1</div>
+      </ons-toolbar>
+
+      <p>This is the first page.</p>
+
+      <ons-button ng-click="myNavigator.pushPage('page2.html', {data: {title: 'Page 2'}})">Push page</ons-button>
+    </ons-page>
+  </template>
+
+  <template id="page2.html">
+    <ons-page ng-controller="Page2Controller as page2" ons-init="page2.init($event)">
+      <ons-toolbar>
+        <div class="left"><ons-back-button>Page 1</ons-back-button></div>
+        <div class="center">{{ myNavigator.topPage.data.title }}</div>
+      </ons-toolbar>
+
+      <p>This is the second page.</p>
+    </ons-page>
+  </template>
+</body>
+</html>
+
+<!-- info
+
+## The Navigator
+
+The `<ons-navigator>`  element handles a stack of pages. This is a very common type of navigation in mobile apps where one page is pushed on top of another using a transition animation.
+
+To change the animation you can use the `animation` attribute:
+
+```
+<ons-navigator animation="fade"></ons-navigator>
+```
+
+Available animations are:
+
+* `fade`
+* `lift`
+* `slide`
+* `none`
+
+For iOS' "swipe to pop" feature, add the `swipeable` attribute. Note that this behavior is automatically removed on Android platforms unless `swipeable="force"` is specified.
+
+## Defining pages
+
+The pages that you push to the Navigator are defined using a `<template>` element.
+
+```
+<template id="page2.html">
+  <ons-page>
+    ...
+  </ons-page>
+</template>
+```
+
+The `id` attribute is used to reference the pages when pushing.
+
+## Pushing pages
+
+To push a new page to the top of the stack, the `pushPage(page, options)` method is used.
+
+In Onsen UI all such methods are attached to the element so you need to create a reference to it. You can do this by using `var` attribute:
+
+```
+<ons-navigator var="myNavigator"></ons-navigator>
+```
+
+This will allow you to call Navigator's method like this: `myNavigator.pushPage('page2.html');`
+
+`pushPage` method returns a `Promise` object that is resolved when the transition is finished. You can try adding the following code:
+
+```
+myNavigator
+  .pushPage('page2.html')
+  .then(function() {
+    ons.notification.alert('Page pushed!');
+  });
+```
+
+## Sending custom data to a new page
+
+It may be useful to have access to custom data when we push a new page. This is achieved by passing `options.data` parameter:
+
+```
+myNavigator
+  .pushPage('page2.html', {
+    data: {
+      title: 'New Page',
+      // ...
+    },
+    // Other options
+  });
+```
+
+`options.data` object can be safely accessed after the `init` event of the new page. `ons-init` handler can be used to handle this event.
+It is also possible to access this object from scope functions or views with `myNavigator.topPage.data`.
+
+
+## Going back
+
+To go back to a previous page the `popPage(options)` method is used.
+
+Another way is to use the `<ons-back-button>` element. It can be added to the left side of the toolbar and renders as an arrow:
+
+```
+<ons-toolbar>
+  <div class="left">
+    <ons-back-button>Back</ons-back-button>
+  </div>
+</ons-toolbar>
+```
+
+It will automatically find the Navigator element and trigger a `popPage()` call so there is no need to attach any click handlers to it.
+
+-->

--- a/tutorial/angular1/reference/checkbox.html
+++ b/tutorial/angular1/reference/checkbox.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+    .controller('PageController', function() {
+      this.apples = true;
+      this.bananas = false;
+    });
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page" >
+  <ons-toolbar>
+    <div class="center">Checkboxes</div>
+  </ons-toolbar>
+
+  <ons-list>
+    <ons-list-item tappable>
+      <label class="left">
+        <ons-checkbox input-id="check-1" ng-model="page.apples"></ons-checkbox>
+      </label>
+      <label for="check-1" class="center">
+        Apples <span ng-show="page.apples" style="color: red; margin-left: 6px">♥</span>
+      </label>
+    </ons-list-item>
+    <ons-list-item tappable>
+      <label class="left">
+        <ons-checkbox input-id="check-2" ng-model="page.bananas"></ons-checkbox>
+      </label>
+      <label for="check-2" class="center">
+        Bananas <span ng-show="page.bananas" style="color: red; margin-left: 6px">♥</span>
+      </label>
+    </ons-list-item>
+  </ons-list>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Checkboxes
+
+Checkboxes are defined using the `<ons-checkbox>` element. The element works almost exactly as when you use a normal `<input type="checkbox">` element.
+
+```
+<ons-checkbox value="something" checked></ons-checkbox>
+```
+
+## Inner input element
+
+For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
+
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+
+```
+<label for="username">Username</label>
+<ons-input input-id="username"></ons-input>
+```
+
+This work with any input in Onsen UI such as checkboxes, radios, etc.
+
+-->

--- a/tutorial/angular1/reference/dialog.html
+++ b/tutorial/angular1/reference/dialog.html
@@ -87,7 +87,7 @@
 
 ## Dialogs
 
-Normal dialogs are defined using the `<ons-dialog>` tag. There is also an `<ons-alert-dialog>` tag that is used to display alert dialogs and an `<ons-toast>` one for toast messages.
+Dialogs are defined using the `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` tags.
 
 ```
 <ons-dialog var="dialog">
@@ -97,7 +97,22 @@ Normal dialogs are defined using the `<ons-dialog>` tag. There is also an `<ons-
 
 `var` attribute is used to store the dialog in a variable for later access.
 
-The dialogs are hidden by default and usually attached as direct childs of the `<body>` tag.
+Alert dialogs work exactly like normal dialogs but they require some additional markup. With this element you can create a beautifully styled dialog without any additional CSS.
+
+```
+<ons-alert-dialog>
+  <div class="alert-dialog-title">Warning!</div>
+  <div class="alert-dialog-content">
+    An error has occurred!
+  </div>
+  <div class="alert-dialog-footer">
+    <button class="alert-dialog-button">Cancel</button>
+    <button class="alert-dialog-button">OK</button>
+  </div>
+</ons-alert-dialog>
+```
+
+Dialogs are hidden by default and usually attached as direct children of the `<body>` tag.
 
 ## Displaying a dialog
 
@@ -125,23 +140,6 @@ ons
 ```
 
 For AngularJS, an extra parameter can be passed to specify the scope of the new popover: `ons.createDialog('dialog.html', { parentScope: $scope });`
-
-## Alert dialogs
-
-Alert dialogs work exactly like normal dialogs but they require some additional markup. With this element you can create a beautifully styled dialog without any additional CSS.
-
-```
-<ons-alert-dialog>
-  <div class="alert-dialog-title">Warning!</div>
-  <div class="alert-dialog-content">
-    An error has occurred!
-  </div>
-  <div class="alert-dialog-footer">
-    <button class="alert-dialog-button">Cancel</button>
-    <button class="alert-dialog-button">OK</button>
-  </div>
-</ons-alert-dialog>
-```
 
 ## The `cancelable` attribute
 

--- a/tutorial/angular1/reference/input.html
+++ b/tutorial/angular1/reference/input.html
@@ -6,31 +6,19 @@
 
   <script>
     ons.bootstrap()
-      .controller('PageController', function() {
-        this.username = '';
-        this.password = '';
+    .controller('PageController', function() {
+      this.username = '';
+      this.password = '';
 
-        this.login = function() {
-          if (this.username === 'bob' && this.password === 'secret') {
-            ons.notification.alert('Congratulations!');
-          }
-          else {
-            ons.notification.alert('Incorrect username or password.');
-          }
-        };
-
-        this.apples = true;
-        this.bananas = false;
-
-        this.labelStyle = {
-          marginLeft: '6px',
-          width: '10px',
-          height: '10px',
-          borderRadius: '100%',
-          backgroundColor: 'transparent',
-          display: 'inline-block'
-        };
-      });
+      this.login = function() {
+        if (this.username === 'bob' && this.password === 'secret') {
+          ons.notification.alert('Congratulations!');
+        }
+        else {
+          ons.notification.alert('Incorrect username or password.');
+        }
+      };
+    });
   </script>
 </head>
 <body>
@@ -38,10 +26,6 @@
     <ons-toolbar>
       <div class="center">Input</div>
     </ons-toolbar>
-
-    <p style="text-align: center; margin-top: 10px">
-      <ons-search-input placeholder="Search"></ons-search-input>
-    </p>
 
     <div style="text-align: center; margin-top: 30px">
       <p>
@@ -54,46 +38,6 @@
         <ons-button ng-click="page.login()">Sign in</ons-button>
       </p>
     </div>
-
-    <ons-list>
-      <ons-list-header>Checkboxes</ons-list-header>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-checkbox input-id="check-1" ng-model="page.apples"></ons-checkbox>
-        </label>
-        <label for="check-1" class="center">
-          Apples <span ng-show="page.apples" style="color: red; margin-left: 6px">♥</span>
-        </label>
-      </ons-list-item>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-checkbox input-id="check-2" ng-model="page.bananas"></ons-checkbox>
-        </label>
-        <label for="check-2" class="center">
-          Bananas <span ng-show="page.bananas" style="color: red; margin-left: 6px">♥</span>
-        </label>
-      </ons-list-item>
-    </ons-list>
-
-    <ons-list>
-      <ons-list-header>Radio buttons <span ng-style="page.labelStyle"></span></ons-list-header>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-radio name="color" input-id="radio-1" ng-model="page.labelStyle.backgroundColor" value="red"></ons-radio>
-        </label>
-        <label for="radio-1" class="center">
-          Red
-        </label>
-      </ons-list-item>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-radio name="color" input-id="radio-2" ng-model="page.labelStyle.backgroundColor" value="blue"></ons-radio>
-        </label>
-        <label for="radio-2" class="center">
-          Blue
-        </label>
-      </ons-list-item>
-    </ons-list>
   </ons-page>
 </body>
 </html>
@@ -129,31 +73,6 @@ The label is defined with the `placeholder` attribute and to activate the animat
   float>
 </ons-input>
 ```
-
-## Checkboxes
-
-Checkboxes are defined using the `<ons-checkbox>` element. The element works almost exactly as when you use a normal `<input type="checkbox">` element.
-
-```
-<ons-checkbox value="something" checked></ons-checkbox>
-```
-
-## Radio buttons
-
-Radio buttons are defined using the `<ons-radio>` element.
-
-```
-<ons-radio checked></ons-radio>
-```
-
-To create a group of radio buttons the `name` attribute is used:
-
-```
-<ons-radio name="group" value="first"></ons-radio>
-<ons-radio name="group" value="second"></ons-radio>
-```
-
-This will enable switching between radio buttons.
 
 ## Inner input element
 

--- a/tutorial/angular1/reference/notification.html
+++ b/tutorial/angular1/reference/notification.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+      .controller('PageController', function () {});
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page">
+    <ons-toolbar>
+      <div class="center">Notifications</div>
+    </ons-toolbar>
+
+    <ons-list>
+      <ons-list-item tappable ng-click="ons.notification.alert('Hello, world')">Alert</ons-list-item>
+      <ons-list-item tappable ng-click="ons.notification.confirm({message: 'Are you ready?'})">Confirmation</ons-list-item>
+      <ons-list-item tappable ng-click="ons.notification.prompt({message: 'What is your name?'})">Prompt</ons-list-item>
+    </ons-list>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Notifications
+
+Dialogs can be displayed with the `ons.notification` methods:
+
+* `ons.notification.alert(options)`
+* `ons.notification.confirm(options)`
+* `ons.notification.prompt(options)`
+* `ons.notification.toast(options)`
+
+These methods all return a `Promise`. For the `confirm` it resolves to the index of the button pressed and for the `prompt` it resolves to the user input.
+
+```
+ons
+  .notification.prompt({message: 'What is your name?'})
+  .then(function(name) {
+    ons.notification.alert('Hello ' + name);
+  });
+```
+
+Alternatively, dialogs can be created with the `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` elements.
+
+-->

--- a/tutorial/angular1/reference/progress-circular.html
+++ b/tutorial/angular1/reference/progress-circular.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+      .controller('PageController', function($interval) {
+        this.v = 20;
+
+        $interval(function() {
+          this.v = (this.v + 2) % 102;
+        }.bind(this), 400)
+      });
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page">
+    <ons-toolbar>
+      <div class="center">Progress</div>
+    </ons-toolbar>
+
+    <ons-progress-bar value="{{page.v}}"></ons-progress-bar>
+
+    <div style="margin: 20px auto; width: 320px;">
+      <p>Loading stuff...</p>
+      <ons-progress-bar value="20" secondary-value="50"></ons-progress-bar>
+    </div>
+
+    <ons-progress-bar indeterminate></ons-progress-bar>
+    <ons-progress-circular value="10"></ons-progress-circular>
+    <ons-progress-circular value="20" secondary-value="50"></ons-progress-circular>
+    <ons-progress-circular indeterminate></ons-progress-circular>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Progress
+
+Onsen UI provide two different progress element: `<ons-progress-bar>` and `ons-progress-circular`.
+
+These elements takes two different values in `value` and `secondary-value` attributes. `indeterminate` attribute is also available.
+
+-->

--- a/tutorial/angular1/reference/radio.html
+++ b/tutorial/angular1/reference/radio.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+    .controller('PageController', function() {
+      this.labelStyle = {
+        marginLeft: '6px',
+        width: '10px',
+        height: '10px',
+        borderRadius: '100%',
+        backgroundColor: 'transparent',
+        display: 'inline-block'
+      };
+    });
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page" >
+  <ons-toolbar>
+    <div class="center">Radio buttons</div>
+  </ons-toolbar>
+
+  <ons-list>
+    <ons-list-header>Radio buttons <span ng-style="page.labelStyle"></span></ons-list-header>
+    <ons-list-item tappable>
+      <label class="left">
+        <ons-radio name="color" input-id="radio-1" ng-model="page.labelStyle.backgroundColor" value="red"></ons-radio>
+      </label>
+      <label for="radio-1" class="center">
+        Red
+      </label>
+    </ons-list-item>
+    <ons-list-item tappable>
+      <label class="left">
+        <ons-radio name="color" input-id="radio-2" ng-model="page.labelStyle.backgroundColor" value="blue"></ons-radio>
+      </label>
+      <label for="radio-2" class="center">
+        Blue
+      </label>
+    </ons-list-item>
+  </ons-list>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Radio buttons
+
+Radio buttons are defined using the `<ons-radio>` element.
+
+```
+<ons-radio checked></ons-radio>
+```
+
+To create a group of radio buttons the `name` attribute is used:
+
+```
+<ons-radio name="group" value="first"></ons-radio>
+<ons-radio name="group" value="second"></ons-radio>
+```
+
+This will enable switching between radio buttons.
+
+## Inner input element
+
+For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
+
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+
+```
+<label for="username">Username</label>
+<ons-input input-id="username"></ons-input>
+```
+
+This work with any input in Onsen UI such as checkboxes, radios, etc.
+
+-->

--- a/tutorial/angular1/reference/search-input.html
+++ b/tutorial/angular1/reference/search-input.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page" >
+    <ons-toolbar>
+      <div class="center">Search input</div>
+    </ons-toolbar>
+
+    <p style="text-align: center; margin-top: 10px">
+      <ons-search-input placeholder="Search"></ons-search-input>
+    </p>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Search inputs
+
+In Onsen UI search input is provided by the `<ons-search-input>` tag. It works almost exactly like the normal `<input type="search">`.
+
+## Inner input element
+
+For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
+
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+
+```
+<label for="username">Username</label>
+<ons-input input-id="username"></ons-input>
+```
+
+This work with any input in Onsen UI such as checkboxes, radios, etc.
+
+-->

--- a/tutorial/angular1/reference/toast.html
+++ b/tutorial/angular1/reference/toast.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+      .controller('PageController', function($scope) {
+        this.showDialog = function() {
+          if (this.dialog) {
+            this.dialog.show();
+          } else {
+            ons.createDialog('dialog.html', { parentScope: $scope })
+              .then(function(dialog) {
+                this.dialog = dialog;
+                dialog.show();
+              }.bind(this));
+          }
+        }.bind(this);
+      });
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page">
+    <ons-toolbar>
+      <div class="center">Dialogs</div>
+    </ons-toolbar>
+
+    <ons-list>
+      <ons-list-header>Showing dialogs</ons-list-header>
+      <ons-list-item tappable ng-click="dialog.show()">Simple dialog</ons-list-item>
+      <ons-list-item tappable ng-click="alertDialog.show()">Alert dialog</ons-list-item>
+      <ons-list-item tappable ng-click="page.showDialog()">From template</ons-list-item>
+      <ons-list-item tappable ng-click="toast.toggle()">Toggle toast</ons-list-item>
+      <ons-list-header>Notifications</ons-list-header>
+      <ons-list-item tappable ng-click="ons.notification.alert('Hello, world')">Alert</ons-list-item>
+      <ons-list-item tappable ng-click="ons.notification.confirm({message: 'Are you ready?'})">Confirmation</ons-list-item>
+      <ons-list-item tappable ng-click="ons.notification.prompt({message: 'What is your name?'})">Prompt</ons-list-item>
+    </ons-list>
+  </ons-page>
+
+  <ons-dialog var="dialog">
+    <div style="text-align: center; padding: 10px;">
+      <p>
+        This is a dialog.
+      </p>
+
+      <p>
+        <ons-button ng-click="dialog.hide()">Close</ons-button>
+      </p>
+    </div>
+  </ons-dialog>
+
+  <ons-alert-dialog var="alertDialog">
+    <div class="alert-dialog-title">Warning!</div>
+    <div class="alert-dialog-content">
+      An error has occurred!
+    </div>
+    <div class="alert-dialog-footer">
+      <button class="alert-dialog-button" ng-click="alertDialog.hide()">Cancel</button>
+      <button class="alert-dialog-button" ng-click="alertDialog.hide()">OK</button>
+    </div>
+  </ons-alert-dialog>
+
+  <template id="dialog.html">
+    <ons-dialog id="dialog-3">
+      <div style="text-align: center; padding: 10px;">
+        <p>
+          This dialog was created from a template.
+        <p>
+
+        <p>
+          <ons-button ng-click="page.dialog.hide()">Close</ons-button>
+        </p>
+      </div>
+    </ons-dialog>
+  </template>
+
+  <ons-toast var="toast">
+    This is an Onsen Toast!<button>Hoge</button>
+  </ons-toast>
+</body>
+</html>
+
+<!-- info
+
+## Dialogs
+
+Dialogs are defined using the `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` tags.
+
+```
+<ons-dialog var="dialog">
+  This is a dialog!
+</ons-dialog>
+```
+
+`var` attribute is used to store the dialog in a variable for later access.
+
+Alert dialogs work exactly like normal dialogs but they require some additional markup. With this element you can create a beautifully styled dialog without any additional CSS.
+
+```
+<ons-alert-dialog>
+  <div class="alert-dialog-title">Warning!</div>
+  <div class="alert-dialog-content">
+    An error has occurred!
+  </div>
+  <div class="alert-dialog-footer">
+    <button class="alert-dialog-button">Cancel</button>
+    <button class="alert-dialog-button">OK</button>
+  </div>
+</ons-alert-dialog>
+```
+
+Dialogs are hidden by default and usually attached as direct children of the `<body>` tag.
+
+## Displaying a dialog
+
+To display a dialog you need to get a reference to the element and execute the `show(options)` method.
+It is hidden with the `hide(options)` method.
+
+## Loading from a template
+
+Another way to use dialogs is with the `ons.createDialog(template)` utility function. The dialog needs to be defined as a template and the function returns a `Promise` that resolves to the dialog element.
+
+```
+<template id="dialog.html">
+  <ons-dialog>
+    This dialog is defined as a template.
+  </ons-dialog>
+</template>
+```
+
+```
+ons
+  .createDialog('dialog.html')
+  .then(function(dialog) {
+    dialog.show();
+  });
+```
+
+For AngularJS, an extra parameter can be passed to specify the scope of the new popover: `ons.createDialog('dialog.html', { parentScope: $scope });`
+
+## The `cancelable` attribute
+
+The `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` support the `cancelable` attribute. This enables hiding the dialog by tapping outside of it or by pressing the back button on Android devices.
+
+```
+<ons-dialog cancelable>
+  This dialog can be cancelled!
+</ons-dialog>
+```
+
+Try adding the `cancelable` attribute to one of the dialogs to see how it works.
+
+## Notification
+
+Another way to display dialogs is with the `ons.notification` methods:
+
+* `ons.notification.alert(options)`
+* `ons.notification.confirm(options)`
+* `ons.notification.prompt(options)`
+* `ons.notification.toast(options)`
+
+These methods all return a `Promise`. For the `confirm` it resolves to the index of the button pressed and for the `prompt` it resolves to the user input.
+
+```
+ons
+  .notification.prompt({message: 'What is your name?'})
+  .then(function(name) {
+    ons.notification.alert('Hello ' + name);
+  });
+```
+
+
+-->

--- a/tutorial/angular1/reference/toolbar.html
+++ b/tutorial/angular1/reference/toolbar.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    ons.bootstrap()
+      .controller('PageController', function() {
+        this.title = 'My app';
+        this.showAlert = function(message) {
+          ons.notification.alert(message);
+        };
+      });
+  </script>
+</head>
+<body>
+  <ons-page ng-controller="PageController as page">
+    <ons-toolbar>
+      <div class="center">{{page.title}}</div>
+      <div class="right">
+        <ons-toolbar-button>
+          <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
+        </ons-toolbar-button>
+      </div>
+    </ons-toolbar>
+
+    <p style="text-align: center">
+      <ons-button ng-click="page.showAlert('Hello world!')">Click me!</ons-button>
+    </p>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## The `<ons-page>` element
+
+The root of a page in Onsen UI is created using the `<ons-page>` element. It covers the whole screen and is used as a container for the other elements. When managing multiple views, all of them must be contained in `<ons-page>` element.
+
+```
+<ons-page>
+  Content goes here
+</ons-page>
+```
+
+This element automatically spawns a `background` and a `content` elements. These can also be manually provided for higher customizability:
+
+```
+<ons-page>
+  Toolbar here
+
+  <div class="background"></div>
+
+  <div class="content">
+    Scrollable content here
+  </div>
+
+  Fixed content here
+</ons-page>
+```
+
+Since `content` element is transparent by default, we can add custom colors to the `background` element. Notice that, if `content` element is provided, scrollable and fixed content must be manually separated as well.
+
+## Adding a toolbar
+
+Most mobile apps have a toolbar at the top containing a header text and maybe some buttons.
+
+In Onsen UI this is achieved using the `<ons-toolbar>` element. It is divided into three sections that are defined using the HTML classes `left`, `center` and `right`.
+
+```html
+<ons-toolbar>
+  <div class="left"></div>
+  <div class="center"></div>
+  <div class="right"></div>
+</ons-toolbar>
+```
+
+## The `ons` object
+
+Onsen UI not only provides custom elements, it also provides an object called `ons` with a lot of useful functions attached to it. In this example we are using `ons.notification.alert` to show an alert dialog.
+
+There are also `confirm` and `prompt` methods available to show other types of dialogs. You can try replacing the click handler with the following code to get another type of dialog:
+
+```javascript
+ons.notification.confirm({message: 'Are you ready?'});
+```
+
+We will take a look at other types of dialogs in a later section.
+
+-->

--- a/tutorial/angular2/reference/alert-dialog.html
+++ b/tutorial/angular2/reference/alert-dialog.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+    import {
+      Component,
+      ComponentRef,
+      ViewChild,
+      Params,
+      OnsenModule,
+      NgModule,
+      CUSTOM_ELEMENTS_SCHEMA
+    } from 'ngx-onsenui';
+    import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+    import * as ons from 'onsenui';
+
+    @Component({
+      selector: 'app',
+      template: `
+      <ons-page class="page">
+        <ons-toolbar>
+          <div class="center">Dialogs</div>
+        </ons-toolbar>
+        <div class="content">
+          <ons-list>
+            <ons-list-header>Notifications</ons-list-header>
+            <ons-list-item tappable (click)="alert()">Alert</ons-list-item>
+            <ons-list-item tappable (click)="confirm()">Confirmation</ons-list-item>
+            <ons-list-item tappable (click)="prompt()">Prompt</ons-list-item>
+            <ons-list-item tappable (click)="toast()">Toast</ons-list-item>
+
+            <ons-list-header>Components</ons-list-header>
+            <ons-list-item tappable (click)="dialog.show()">Simple Dialog</ons-list-item>
+            <ons-list-item tappable (click)="alertDialog.show()">Alert Dialog</ons-list-item>
+            </ons-list>
+        </div>
+      </ons-page>
+
+      <!-- must be located just under an outermost box such as body element -->
+      <ons-dialog animation="default" cancelable #dialog>
+        <div class="dialog-mask"></div>
+          <div class="dialog">
+            <div class="dialog-container" style="height: 200px;">
+              <ons-page>
+                <ons-toolbar>
+                  <div class="center">Name</div>
+                </ons-toolbar>
+                <div class="content">
+                  <div style="text-align: center">
+                    <p>This is just an example.</p>
+                    <br>
+                    <ons-button (click)="dialog.hide()">Close</ons-button>
+                  </div>
+                </div>
+              </ons-page>
+            </div>
+          </div>
+      </ons-dialog>
+
+      <!-- must be located just under an outermost box such as body element -->
+      <ons-alert-dialog cancelable #alertDialog>
+        <div class="alert-dialog-title">Warning!</div>
+        <div class="alert-dialog-content">
+          This is just an example.
+        </div>
+        <div class="alert-dialog-footer">
+          <ons-alert-dialog-button (click)="alertDialog.hide()">OK</ons-alert-dialog-button>
+        </div>
+      </ons-alert-dialog>
+      `
+    })
+    export class AppComponent {
+      constructor() {
+      }
+
+      alert() {
+        ons.notification.alert('Hello, world!');
+      }
+
+      confirm() {
+        ons.notification.confirm({
+          message: 'This dialog can be canceled by tapping the background or using the back button on your device.',
+          cancelable: true,
+          callback: i => {
+            if (i == -1) {
+              ons.notification.alert({message: 'You canceled it!'});
+            }
+          }
+        });
+      }
+
+      prompt() {
+        ons.notification.prompt({
+          message: 'What is the meaning of Life, the Universe and Everything?',
+          callback: answer => {
+            if (answer === '42') {
+              ons.notification.alert({message: 'That\'s the correct answer!'});
+            } else {
+              ons.notification.alert({message: 'Incorrect! Please try again!'});
+            }
+          }
+        });
+      }
+
+      toast() {
+        ons.notification.toast('Hello, world!', {timeout: 2000});
+      }
+    }
+
+    @NgModule({
+      imports: [OnsenModule],
+      declarations: [AppComponent],
+      bootstrap: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    })
+    class AppModule { }
+
+    platformBrowserDynamic().bootstrapModule(AppModule);
+  </script>
+
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+Tutorial will be added soon.
+
+-->
+
+<!-- lang=ja
+
+## Dialog
+
+Onsen UIではダイアログを表示する方法がいくつかあります。このチュートリアルでは次のダイアログの使い方を解説します。
+
+ * onsNotification
+ * ons-alert-dialogとAlertDialogFactory
+ * ons-dialogとDialogFactory
+
+## onsNotification
+
+`onsNotification`は単純なアラートダイアログを表示することができます。`onsNotification`の持つ`alert()`, `confirm()`, `prompt()`メソッドの役割は、`window.alert()`や`window.confirm()`や`window.prompt()`と対応しています。
+
+```
+import onsNotification from 'angular2-onsenui';
+
+// アラートを表示する
+onsNotification.alert('Hello World!');
+```
+
+確認ダイアログを表示するには、`onsNotification.confirm()`を使います。
+
+```
+onsNotification.confirm({
+  message: 'This dialog can be canceled by tapping the background or using the back button on your device.',
+  cancelable: true,
+  callback: i => {
+    if (i == -1) {
+      // canselされた場合iは-1が代入される
+      onsNotification.alert({message: 'You canceled it!'});
+    }
+  }
+});
+```
+
+プロンプトを表示するには、`onsNotification.prompt()`を用います。
+
+```
+onsNotification.prompt({
+  message: 'What is the meaning of Life, the Universe and Everything?',
+  callback: answer => {
+    if (answer === '42') {
+      onsNotification.alert({message: 'That\'s the correct answer!'});
+    } else {
+      onsNotification.alert({message: 'Incorrect! Please try again!'});
+    }
+  }
+});
+```
+
+onsNotificationはons.notificationのラッパーです。APIの詳細は、ons.notificationのリファレンスを参照してください。
+
+## `<ons-alert-dialog>`とAlertDialogFactory
+
+単純なアラートダイアログではなく、振る舞いやコンテンツをカスタマイズしたい場合には、`<ons-alert-dialog>`要素とAlertDialogFactoryを利用します。
+
+onsNotificationの場合とは違って、Angular 2アプリケーション下で`<ons-alert-dialog>`要素を使うには手順が必要です。まず、`<ons-alert-dialog>`を使ってComponentを宣言します。
+
+```
+@Component({
+  template: `
+    <ons-alert-dialog cancelable #alert>
+      <div class="alert-dialog-title">Warning!</div>
+      <div class="alert-dialog-content">
+        Hello World!
+      </div>
+      <div class="alert-dialog-footer">
+        <button class="alert-dialog-button" (click)="alert.hide()">OK</button>
+      </div>
+    </ons-alert-dialog>
+  `
+})
+class MyAlertDialogComponent {
+}
+```
+
+次にこのコンポーネントとして呼び出すにはAlertDialogFactoryを使います。AlertDialogFactoryオブジェクトは次のようにコンポーネントのコンストラクタの引数に指定することでAngular 2のDIを通じて取得することができます。
+
+```
+@Component({
+  'selector': 'app',
+  'template': '<div></div>'
+})
+export class AppComponent {
+  constructor(adf: AlertDialogFactory) {
+  }
+}
+```
+
+AlertDialogFactoryは、`<ons-alert-dialog>`を使っているコンポーネントを動的に生成することができます。初期化時にダイアログを生成したい場合には、次のようにコンポーネントの`ngAfterViewInit()`内で`createAlertDialog()`メソッドを使ってください。
+
+また、一度作成したアラートダイアログは`destroy`関数で必ず消して下さい。ドキュメントのDOMツリーの中に保持されし続けるので、DOMリークを引き起こします。
+
+```
+export class AppComponent implements AfterViewInit, OnDestroy {
+  private _alert: any;
+  private _destroyAlert: Function;
+
+  constructor(private _adf: AlertDialogFactory) {
+  }
+
+  ngAfterViewInit() {
+    this._adf
+      .createAlertDialog(MyAlertDialogComponent, {message: 'This is just an example.'})
+      .then(({alertDialog, destroy}) => {
+        this._alert = alertDialog;
+        this._alert.show();
+        this._destroyAlert = destroy;
+      });
+  }
+
+  ngOnDestroy() {
+    this._destroyAlert();
+  }
+}
+
+```
+
+ビューの初期化が行われていない`constructor()`内で`createAlertDialog()`を呼び出すとエラーを引き起こすことに注意してください。
+
+## パラメータを受け取る
+
+`createAlertDialog()`の第二引数には、任意のデータを渡すことができます。
+
+```
+this._adf
+  .createAlertDialog(MyAlertDialogComponent, {message: 'This is just an example.'})
+  .then(({alertDialog, destroy}) => {
+    // ...
+  });
+```
+
+ここで渡したデータは、AlertDialogのコンポーネントのコンストラクタから取得することができます。
+
+```
+class MyAlertDialogComponent {
+  message = '';
+
+  constructor(params: Params) {
+    this.message = <string>params.at('message');
+  }
+}
+```
+
+## NgModule
+
+AlertDialogFactoryで読み込むコンポーネントは動的に読み込まれるものであるため、`NgModule`の`declarations`と`entryComponents`に追加することを忘れないでください。
+
+```
+@NgModule({
+  imports: [OnsenModule],
+  declarations: [AppComponent, MyAlertDialogComponent],
+  bootstrap: [AppComponent],
+  entryComponents: [MyAlertDialogComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+class AppModule { }
+```
+
+## `<ons-dialog>`とDialogFactory
+
+アラートダイアログではなく、`<ons-page>`や`<ons-navigator>`などを埋め込めるダイアログを表示する場合には、`<ons-dialog>`を使います。
+
+`<ons-dialog>`をAngular 2で生成するには、DialogFactoryを使います。先ほど紹介したAlertDialogFactoryとほとんど同じ方法で使うことができます。
+
+```
+@Component({
+  template: `
+    <ons-dialog #dialog>
+      <div class="dialog-mask"></div>
+      <div class="dialog">
+        <div class="dialog-container" style="height: 200px;">
+          <ons-page>
+            <ons-toolbar>
+              <div class="center">Name</div>
+            </ons-toolbar>
+            <div class="content">
+              <div style="text-align: center">
+                <p>{{message}}</p>
+                <br>
+                <ons-button (click)="dialog.hide()">Close</ons-button>
+              </div>
+            </div>
+          </ons-page>
+        </div>
+      </div>
+    </ons-dialog>
+  `
+})
+class MyDialogComponent {
+  message = '';
+
+  constructor(params: Params) {
+    this.message = <string>params.at('message');
+  }
+}
+```
+
+DialogFactoryを通じてこのMyDialogComponentを初期化します。
+
+```
+export class AppComponent implements AfterViewInit, OnDestroy {
+  private _dialog: any;
+  private _destroyDialog: Function;
+
+  constructor(private _df: DialogFactory) {
+  }
+
+  ngAfterViewInit() {
+    this._df
+      .createDialog(MyDialogComponent, {message: 'This is just an example.'})
+      .then(({dialog, destroy}) => {
+        this._dialog = dialog;
+        this._destroyDialog = destroy;
+      });
+  }
+
+  ngOnDestroy() {
+    this._destroyDialog();
+  }
+}
+```
+
+AlertDialogの場合と同様に、初期化時に渡されるdestroy関数を終了時に呼び出すことを忘れないでください。
+
+-->

--- a/tutorial/angular2/reference/back-button.html
+++ b/tutorial/angular2/reference/back-button.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+  import {
+    Component,
+    ViewChild,
+    Params,
+    OnsNavigator,
+    OnsenModule,
+    NgModule,
+    CUSTOM_ELEMENTS_SCHEMA
+  } from 'ngx-onsenui';
+  import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+  @Component({
+    selector: 'ons-page',
+    template: `
+      <ons-toolbar>
+        <div class="left"><ons-back-button>Back</ons-back-button></div>
+        <div class="center">Page2</div>
+      </ons-toolbar>
+      <div class="content">
+        <div style="text-align: center; margin: 10px">
+          <ons-button (click)="push()">push</ons-button>
+          <ons-button (click)="pop()">pop</ons-button>
+          <p>page2</p>
+        </div>
+      </div>
+    `
+  })
+  export class PageComponent {
+    constructor(private _navigator: OnsNavigator, private _params: Params) {
+      console.log('parameters:', _params.data);
+    }
+
+    push() {
+      this._navigator.element.pushPage(PageComponent, {animation: 'slide', data: {aaa: 'bbb'}});
+    }
+
+    pop() {
+      this._navigator.element.popPage();
+    }
+  }
+
+  @Component({
+    selector: 'ons-page',
+    template: `
+      <ons-toolbar>
+        <div class="center">Page</div>
+      </ons-toolbar>
+      <div class="content">
+        <div style="text-align: center; margin: 10px">
+          <ons-button (click)="push(navi)">push</ons-button>
+        </div>
+      </div>
+    `
+  })
+  class DefaultPageComponent {
+
+    constructor(private _navigator: OnsNavigator) {
+    }
+
+    push() {
+      this._navigator.element.pushPage(PageComponent, {data: {hoge: "fuga"}});
+    }
+  }
+
+  @Component({
+    selector: 'app',
+    template: `
+    <ons-navigator swipeable [page]="page"></ons-navigator>
+    `
+  })
+  export class AppComponent {
+    page = DefaultPageComponent
+  }
+
+  @NgModule({
+    imports: [OnsenModule],
+    declarations: [AppComponent, DefaultPageComponent, PageComponent],
+    entryComponents: [DefaultPageComponent, PageComponent],
+    bootstrap: [AppComponent],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  })
+  class AppModule { }
+
+  platformBrowserDynamic().bootstrapModule(AppModule);
+
+  </script>
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+## Stack Navigation
+
+Stack navigation is done by `OnsNavigator` directive. For more details, please see [OnsNavigator Reference](https://onsen.io/v2/docs/angular2/ons-navigator.html).
+
+Tutorial contents will be added soon.
+-->

--- a/tutorial/angular2/reference/checkbox.html
+++ b/tutorial/angular2/reference/checkbox.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+  import {
+    Component,
+    OnsenModule,
+    NgModule,
+    CUSTOM_ELEMENTS_SCHEMA
+  } from 'ngx-onsenui';
+  import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+  @Component({
+    selector: 'app',
+    template: `
+    <ons-page>
+      <ons-toolbar>
+        <div class="center">Input</div>
+      </ons-toolbar>
+      <div class="background"></div>
+      <div class="content">
+        <div style="padding: 10px">
+          <div><ons-input placeholder="Type here" [(value)]="target"></ons-input></div>
+
+          <p>Text: {{target}}</p>
+        </div>
+      </div>
+    </ons-page>
+    `
+  })
+  export class AppComponent{
+    target: string = '';
+  }
+
+  @NgModule({
+    imports: [OnsenModule],
+    declarations: [AppComponent],
+    bootstrap: [AppComponent],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  })
+  class AppModule { }
+
+  platformBrowserDynamic().bootstrapModule(AppModule);
+
+  </script>
+
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+## Input
+
+`ons-input` element renders a input box. Please refer to [ons-input element Reference](https://onsen.io/v2/docs/angular2/ons-input.html) for more details.
+
+Tutorial contents will be added soon.
+
+-->

--- a/tutorial/angular2/reference/notification.html
+++ b/tutorial/angular2/reference/notification.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+    import {
+      Component,
+      ComponentRef,
+      ViewChild,
+      Params,
+      OnsenModule,
+      NgModule,
+      CUSTOM_ELEMENTS_SCHEMA
+    } from 'ngx-onsenui';
+    import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+    import * as ons from 'onsenui';
+
+    @Component({
+      selector: 'app',
+      template: `
+      <ons-page class="page">
+        <ons-toolbar>
+          <div class="center">Dialogs</div>
+        </ons-toolbar>
+        <div class="content">
+          <ons-list>
+            <ons-list-header>Notifications</ons-list-header>
+            <ons-list-item tappable (click)="alert()">Alert</ons-list-item>
+            <ons-list-item tappable (click)="confirm()">Confirmation</ons-list-item>
+            <ons-list-item tappable (click)="prompt()">Prompt</ons-list-item>
+            <ons-list-item tappable (click)="toast()">Toast</ons-list-item>
+
+            <ons-list-header>Components</ons-list-header>
+            <ons-list-item tappable (click)="dialog.show()">Simple Dialog</ons-list-item>
+            <ons-list-item tappable (click)="alertDialog.show()">Alert Dialog</ons-list-item>
+            </ons-list>
+        </div>
+      </ons-page>
+
+      <!-- must be located just under an outermost box such as body element -->
+      <ons-dialog animation="default" cancelable #dialog>
+        <div class="dialog-mask"></div>
+          <div class="dialog">
+            <div class="dialog-container" style="height: 200px;">
+              <ons-page>
+                <ons-toolbar>
+                  <div class="center">Name</div>
+                </ons-toolbar>
+                <div class="content">
+                  <div style="text-align: center">
+                    <p>This is just an example.</p>
+                    <br>
+                    <ons-button (click)="dialog.hide()">Close</ons-button>
+                  </div>
+                </div>
+              </ons-page>
+            </div>
+          </div>
+      </ons-dialog>
+
+      <!-- must be located just under an outermost box such as body element -->
+      <ons-alert-dialog cancelable #alertDialog>
+        <div class="alert-dialog-title">Warning!</div>
+        <div class="alert-dialog-content">
+          This is just an example.
+        </div>
+        <div class="alert-dialog-footer">
+          <ons-alert-dialog-button (click)="alertDialog.hide()">OK</ons-alert-dialog-button>
+        </div>
+      </ons-alert-dialog>
+      `
+    })
+    export class AppComponent {
+      constructor() {
+      }
+
+      alert() {
+        ons.notification.alert('Hello, world!');
+      }
+
+      confirm() {
+        ons.notification.confirm({
+          message: 'This dialog can be canceled by tapping the background or using the back button on your device.',
+          cancelable: true,
+          callback: i => {
+            if (i == -1) {
+              ons.notification.alert({message: 'You canceled it!'});
+            }
+          }
+        });
+      }
+
+      prompt() {
+        ons.notification.prompt({
+          message: 'What is the meaning of Life, the Universe and Everything?',
+          callback: answer => {
+            if (answer === '42') {
+              ons.notification.alert({message: 'That\'s the correct answer!'});
+            } else {
+              ons.notification.alert({message: 'Incorrect! Please try again!'});
+            }
+          }
+        });
+      }
+
+      toast() {
+        ons.notification.toast('Hello, world!', {timeout: 2000});
+      }
+    }
+
+    @NgModule({
+      imports: [OnsenModule],
+      declarations: [AppComponent],
+      bootstrap: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    })
+    class AppModule { }
+
+    platformBrowserDynamic().bootstrapModule(AppModule);
+  </script>
+
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+Tutorial will be added soon.
+
+-->
+
+<!-- lang=ja
+
+## Dialog
+
+Onsen UIではダイアログを表示する方法がいくつかあります。このチュートリアルでは次のダイアログの使い方を解説します。
+
+ * onsNotification
+ * ons-alert-dialogとAlertDialogFactory
+ * ons-dialogとDialogFactory
+
+## onsNotification
+
+`onsNotification`は単純なアラートダイアログを表示することができます。`onsNotification`の持つ`alert()`, `confirm()`, `prompt()`メソッドの役割は、`window.alert()`や`window.confirm()`や`window.prompt()`と対応しています。
+
+```
+import onsNotification from 'angular2-onsenui';
+
+// アラートを表示する
+onsNotification.alert('Hello World!');
+```
+
+確認ダイアログを表示するには、`onsNotification.confirm()`を使います。
+
+```
+onsNotification.confirm({
+  message: 'This dialog can be canceled by tapping the background or using the back button on your device.',
+  cancelable: true,
+  callback: i => {
+    if (i == -1) {
+      // canselされた場合iは-1が代入される
+      onsNotification.alert({message: 'You canceled it!'});
+    }
+  }
+});
+```
+
+プロンプトを表示するには、`onsNotification.prompt()`を用います。
+
+```
+onsNotification.prompt({
+  message: 'What is the meaning of Life, the Universe and Everything?',
+  callback: answer => {
+    if (answer === '42') {
+      onsNotification.alert({message: 'That\'s the correct answer!'});
+    } else {
+      onsNotification.alert({message: 'Incorrect! Please try again!'});
+    }
+  }
+});
+```
+
+onsNotificationはons.notificationのラッパーです。APIの詳細は、ons.notificationのリファレンスを参照してください。
+
+## `<ons-alert-dialog>`とAlertDialogFactory
+
+単純なアラートダイアログではなく、振る舞いやコンテンツをカスタマイズしたい場合には、`<ons-alert-dialog>`要素とAlertDialogFactoryを利用します。
+
+onsNotificationの場合とは違って、Angular 2アプリケーション下で`<ons-alert-dialog>`要素を使うには手順が必要です。まず、`<ons-alert-dialog>`を使ってComponentを宣言します。
+
+```
+@Component({
+  template: `
+    <ons-alert-dialog cancelable #alert>
+      <div class="alert-dialog-title">Warning!</div>
+      <div class="alert-dialog-content">
+        Hello World!
+      </div>
+      <div class="alert-dialog-footer">
+        <button class="alert-dialog-button" (click)="alert.hide()">OK</button>
+      </div>
+    </ons-alert-dialog>
+  `
+})
+class MyAlertDialogComponent {
+}
+```
+
+次にこのコンポーネントとして呼び出すにはAlertDialogFactoryを使います。AlertDialogFactoryオブジェクトは次のようにコンポーネントのコンストラクタの引数に指定することでAngular 2のDIを通じて取得することができます。
+
+```
+@Component({
+  'selector': 'app',
+  'template': '<div></div>'
+})
+export class AppComponent {
+  constructor(adf: AlertDialogFactory) {
+  }
+}
+```
+
+AlertDialogFactoryは、`<ons-alert-dialog>`を使っているコンポーネントを動的に生成することができます。初期化時にダイアログを生成したい場合には、次のようにコンポーネントの`ngAfterViewInit()`内で`createAlertDialog()`メソッドを使ってください。
+
+また、一度作成したアラートダイアログは`destroy`関数で必ず消して下さい。ドキュメントのDOMツリーの中に保持されし続けるので、DOMリークを引き起こします。
+
+```
+export class AppComponent implements AfterViewInit, OnDestroy {
+  private _alert: any;
+  private _destroyAlert: Function;
+
+  constructor(private _adf: AlertDialogFactory) {
+  }
+
+  ngAfterViewInit() {
+    this._adf
+      .createAlertDialog(MyAlertDialogComponent, {message: 'This is just an example.'})
+      .then(({alertDialog, destroy}) => {
+        this._alert = alertDialog;
+        this._alert.show();
+        this._destroyAlert = destroy;
+      });
+  }
+
+  ngOnDestroy() {
+    this._destroyAlert();
+  }
+}
+
+```
+
+ビューの初期化が行われていない`constructor()`内で`createAlertDialog()`を呼び出すとエラーを引き起こすことに注意してください。
+
+## パラメータを受け取る
+
+`createAlertDialog()`の第二引数には、任意のデータを渡すことができます。
+
+```
+this._adf
+  .createAlertDialog(MyAlertDialogComponent, {message: 'This is just an example.'})
+  .then(({alertDialog, destroy}) => {
+    // ...
+  });
+```
+
+ここで渡したデータは、AlertDialogのコンポーネントのコンストラクタから取得することができます。
+
+```
+class MyAlertDialogComponent {
+  message = '';
+
+  constructor(params: Params) {
+    this.message = <string>params.at('message');
+  }
+}
+```
+
+## NgModule
+
+AlertDialogFactoryで読み込むコンポーネントは動的に読み込まれるものであるため、`NgModule`の`declarations`と`entryComponents`に追加することを忘れないでください。
+
+```
+@NgModule({
+  imports: [OnsenModule],
+  declarations: [AppComponent, MyAlertDialogComponent],
+  bootstrap: [AppComponent],
+  entryComponents: [MyAlertDialogComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+class AppModule { }
+```
+
+## `<ons-dialog>`とDialogFactory
+
+アラートダイアログではなく、`<ons-page>`や`<ons-navigator>`などを埋め込めるダイアログを表示する場合には、`<ons-dialog>`を使います。
+
+`<ons-dialog>`をAngular 2で生成するには、DialogFactoryを使います。先ほど紹介したAlertDialogFactoryとほとんど同じ方法で使うことができます。
+
+```
+@Component({
+  template: `
+    <ons-dialog #dialog>
+      <div class="dialog-mask"></div>
+      <div class="dialog">
+        <div class="dialog-container" style="height: 200px;">
+          <ons-page>
+            <ons-toolbar>
+              <div class="center">Name</div>
+            </ons-toolbar>
+            <div class="content">
+              <div style="text-align: center">
+                <p>{{message}}</p>
+                <br>
+                <ons-button (click)="dialog.hide()">Close</ons-button>
+              </div>
+            </div>
+          </ons-page>
+        </div>
+      </div>
+    </ons-dialog>
+  `
+})
+class MyDialogComponent {
+  message = '';
+
+  constructor(params: Params) {
+    this.message = <string>params.at('message');
+  }
+}
+```
+
+DialogFactoryを通じてこのMyDialogComponentを初期化します。
+
+```
+export class AppComponent implements AfterViewInit, OnDestroy {
+  private _dialog: any;
+  private _destroyDialog: Function;
+
+  constructor(private _df: DialogFactory) {
+  }
+
+  ngAfterViewInit() {
+    this._df
+      .createDialog(MyDialogComponent, {message: 'This is just an example.'})
+      .then(({dialog, destroy}) => {
+        this._dialog = dialog;
+        this._destroyDialog = destroy;
+      });
+  }
+
+  ngOnDestroy() {
+    this._destroyDialog();
+  }
+}
+```
+
+AlertDialogの場合と同様に、初期化時に渡されるdestroy関数を終了時に呼び出すことを忘れないでください。
+
+-->

--- a/tutorial/angular2/reference/progress-circular.html
+++ b/tutorial/angular2/reference/progress-circular.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/typescript">
+    import {
+      Component,
+      OnsenModule,
+      NgModule,
+      CUSTOM_ELEMENTS_SCHEMA
+    } from 'ngx-onsenui';
+    import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+    @Component({
+      selector: 'app',
+      template: `
+      <ons-page class="page">
+        <ons-toolbar>
+          <div class="center">Progress</div>
+        </ons-toolbar>
+        <div class="background"></div>
+        <div class="content">
+          <ons-progress-bar [value]="v"></ons-progress-bar>
+
+          <div style="margin: 20px auto; width: 320px;">
+            <p>Loading stuff...</p>
+            <ons-progress-bar value="20" secondary-value="50"></ons-progress-bar>
+          </div>
+
+          <div>
+            <ons-progress-bar indeterminate></ons-progress-bar>
+          </div>
+
+          <div style="margin: 20px; text-align: center;">
+            <ons-progress-circular [value]="v"></ons-progress-circular>
+            <ons-progress-circular value="20" secondary-value="50"></ons-progress-circular>
+            <ons-progress-circular indeterminate></ons-progress-circular>
+          </div>
+        </div>
+      </ons-page>
+      `
+    })
+    export class AppComponent{
+      v: number = 0;
+
+      constructor() {
+        setInterval(() => {
+          this.v = (this.v + 10) % 110;
+        }, 800);
+      }
+    }
+
+    @NgModule({
+      imports: [OnsenModule],
+      declarations: [AppComponent],
+      bootstrap: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    })
+    class AppModule { }
+
+    platformBrowserDynamic().bootstrapModule(AppModule);
+  </script>
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+## Progress indicators
+
+Tutorial contents will be added soon.
+
+-->

--- a/tutorial/angular2/reference/radio.html
+++ b/tutorial/angular2/reference/radio.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+  import {
+    Component,
+    OnsenModule,
+    NgModule,
+    CUSTOM_ELEMENTS_SCHEMA
+  } from 'ngx-onsenui';
+  import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+  @Component({
+    selector: 'app',
+    template: `
+    <ons-page>
+      <ons-toolbar>
+        <div class="center">Input</div>
+      </ons-toolbar>
+      <div class="background"></div>
+      <div class="content">
+        <div style="padding: 10px">
+          <div><ons-input placeholder="Type here" [(value)]="target"></ons-input></div>
+
+          <p>Text: {{target}}</p>
+        </div>
+      </div>
+    </ons-page>
+    `
+  })
+  export class AppComponent{
+    target: string = '';
+  }
+
+  @NgModule({
+    imports: [OnsenModule],
+    declarations: [AppComponent],
+    bootstrap: [AppComponent],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  })
+  class AppModule { }
+
+  platformBrowserDynamic().bootstrapModule(AppModule);
+
+  </script>
+
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+## Input
+
+`ons-input` element renders a input box. Please refer to [ons-input element Reference](https://onsen.io/v2/docs/angular2/ons-input.html) for more details.
+
+Tutorial contents will be added soon.
+
+-->

--- a/tutorial/angular2/reference/search-input.html
+++ b/tutorial/angular2/reference/search-input.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+  import {
+    Component,
+    OnsenModule,
+    NgModule,
+    CUSTOM_ELEMENTS_SCHEMA
+  } from 'ngx-onsenui';
+  import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+  @Component({
+    selector: 'app',
+    template: `
+    <ons-page>
+      <ons-toolbar>
+        <div class="center">Input</div>
+      </ons-toolbar>
+      <div class="background"></div>
+      <div class="content">
+        <div style="padding: 10px">
+          <div><ons-input placeholder="Type here" [(value)]="target"></ons-input></div>
+
+          <p>Text: {{target}}</p>
+        </div>
+      </div>
+    </ons-page>
+    `
+  })
+  export class AppComponent{
+    target: string = '';
+  }
+
+  @NgModule({
+    imports: [OnsenModule],
+    declarations: [AppComponent],
+    bootstrap: [AppComponent],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  })
+  class AppModule { }
+
+  platformBrowserDynamic().bootstrapModule(AppModule);
+
+  </script>
+
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+## Input
+
+`ons-input` element renders a input box. Please refer to [ons-input element Reference](https://onsen.io/v2/docs/angular2/ons-input.html) for more details.
+
+Tutorial contents will be added soon.
+
+-->

--- a/tutorial/angular2/reference/toast.html
+++ b/tutorial/angular2/reference/toast.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script type="text/typescript">
+    import {
+      Component,
+      ComponentRef,
+      ViewChild,
+      Params,
+      OnsenModule,
+      NgModule,
+      CUSTOM_ELEMENTS_SCHEMA
+    } from 'ngx-onsenui';
+    import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+    import * as ons from 'onsenui';
+
+    @Component({
+      selector: 'app',
+      template: `
+      <ons-page class="page">
+        <ons-toolbar>
+          <div class="center">Dialogs</div>
+        </ons-toolbar>
+        <div class="content">
+          <ons-list>
+            <ons-list-header>Notifications</ons-list-header>
+            <ons-list-item tappable (click)="alert()">Alert</ons-list-item>
+            <ons-list-item tappable (click)="confirm()">Confirmation</ons-list-item>
+            <ons-list-item tappable (click)="prompt()">Prompt</ons-list-item>
+            <ons-list-item tappable (click)="toast()">Toast</ons-list-item>
+
+            <ons-list-header>Components</ons-list-header>
+            <ons-list-item tappable (click)="dialog.show()">Simple Dialog</ons-list-item>
+            <ons-list-item tappable (click)="alertDialog.show()">Alert Dialog</ons-list-item>
+            </ons-list>
+        </div>
+      </ons-page>
+
+      <!-- must be located just under an outermost box such as body element -->
+      <ons-dialog animation="default" cancelable #dialog>
+        <div class="dialog-mask"></div>
+          <div class="dialog">
+            <div class="dialog-container" style="height: 200px;">
+              <ons-page>
+                <ons-toolbar>
+                  <div class="center">Name</div>
+                </ons-toolbar>
+                <div class="content">
+                  <div style="text-align: center">
+                    <p>This is just an example.</p>
+                    <br>
+                    <ons-button (click)="dialog.hide()">Close</ons-button>
+                  </div>
+                </div>
+              </ons-page>
+            </div>
+          </div>
+      </ons-dialog>
+
+      <!-- must be located just under an outermost box such as body element -->
+      <ons-alert-dialog cancelable #alertDialog>
+        <div class="alert-dialog-title">Warning!</div>
+        <div class="alert-dialog-content">
+          This is just an example.
+        </div>
+        <div class="alert-dialog-footer">
+          <ons-alert-dialog-button (click)="alertDialog.hide()">OK</ons-alert-dialog-button>
+        </div>
+      </ons-alert-dialog>
+      `
+    })
+    export class AppComponent {
+      constructor() {
+      }
+
+      alert() {
+        ons.notification.alert('Hello, world!');
+      }
+
+      confirm() {
+        ons.notification.confirm({
+          message: 'This dialog can be canceled by tapping the background or using the back button on your device.',
+          cancelable: true,
+          callback: i => {
+            if (i == -1) {
+              ons.notification.alert({message: 'You canceled it!'});
+            }
+          }
+        });
+      }
+
+      prompt() {
+        ons.notification.prompt({
+          message: 'What is the meaning of Life, the Universe and Everything?',
+          callback: answer => {
+            if (answer === '42') {
+              ons.notification.alert({message: 'That\'s the correct answer!'});
+            } else {
+              ons.notification.alert({message: 'Incorrect! Please try again!'});
+            }
+          }
+        });
+      }
+
+      toast() {
+        ons.notification.toast('Hello, world!', {timeout: 2000});
+      }
+    }
+
+    @NgModule({
+      imports: [OnsenModule],
+      declarations: [AppComponent],
+      bootstrap: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    })
+    class AppModule { }
+
+    platformBrowserDynamic().bootstrapModule(AppModule);
+  </script>
+
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+Tutorial will be added soon.
+
+-->
+
+<!-- lang=ja
+
+## Dialog
+
+Onsen UIではダイアログを表示する方法がいくつかあります。このチュートリアルでは次のダイアログの使い方を解説します。
+
+ * onsNotification
+ * ons-alert-dialogとAlertDialogFactory
+ * ons-dialogとDialogFactory
+
+## onsNotification
+
+`onsNotification`は単純なアラートダイアログを表示することができます。`onsNotification`の持つ`alert()`, `confirm()`, `prompt()`メソッドの役割は、`window.alert()`や`window.confirm()`や`window.prompt()`と対応しています。
+
+```
+import onsNotification from 'angular2-onsenui';
+
+// アラートを表示する
+onsNotification.alert('Hello World!');
+```
+
+確認ダイアログを表示するには、`onsNotification.confirm()`を使います。
+
+```
+onsNotification.confirm({
+  message: 'This dialog can be canceled by tapping the background or using the back button on your device.',
+  cancelable: true,
+  callback: i => {
+    if (i == -1) {
+      // canselされた場合iは-1が代入される
+      onsNotification.alert({message: 'You canceled it!'});
+    }
+  }
+});
+```
+
+プロンプトを表示するには、`onsNotification.prompt()`を用います。
+
+```
+onsNotification.prompt({
+  message: 'What is the meaning of Life, the Universe and Everything?',
+  callback: answer => {
+    if (answer === '42') {
+      onsNotification.alert({message: 'That\'s the correct answer!'});
+    } else {
+      onsNotification.alert({message: 'Incorrect! Please try again!'});
+    }
+  }
+});
+```
+
+onsNotificationはons.notificationのラッパーです。APIの詳細は、ons.notificationのリファレンスを参照してください。
+
+## `<ons-alert-dialog>`とAlertDialogFactory
+
+単純なアラートダイアログではなく、振る舞いやコンテンツをカスタマイズしたい場合には、`<ons-alert-dialog>`要素とAlertDialogFactoryを利用します。
+
+onsNotificationの場合とは違って、Angular 2アプリケーション下で`<ons-alert-dialog>`要素を使うには手順が必要です。まず、`<ons-alert-dialog>`を使ってComponentを宣言します。
+
+```
+@Component({
+  template: `
+    <ons-alert-dialog cancelable #alert>
+      <div class="alert-dialog-title">Warning!</div>
+      <div class="alert-dialog-content">
+        Hello World!
+      </div>
+      <div class="alert-dialog-footer">
+        <button class="alert-dialog-button" (click)="alert.hide()">OK</button>
+      </div>
+    </ons-alert-dialog>
+  `
+})
+class MyAlertDialogComponent {
+}
+```
+
+次にこのコンポーネントとして呼び出すにはAlertDialogFactoryを使います。AlertDialogFactoryオブジェクトは次のようにコンポーネントのコンストラクタの引数に指定することでAngular 2のDIを通じて取得することができます。
+
+```
+@Component({
+  'selector': 'app',
+  'template': '<div></div>'
+})
+export class AppComponent {
+  constructor(adf: AlertDialogFactory) {
+  }
+}
+```
+
+AlertDialogFactoryは、`<ons-alert-dialog>`を使っているコンポーネントを動的に生成することができます。初期化時にダイアログを生成したい場合には、次のようにコンポーネントの`ngAfterViewInit()`内で`createAlertDialog()`メソッドを使ってください。
+
+また、一度作成したアラートダイアログは`destroy`関数で必ず消して下さい。ドキュメントのDOMツリーの中に保持されし続けるので、DOMリークを引き起こします。
+
+```
+export class AppComponent implements AfterViewInit, OnDestroy {
+  private _alert: any;
+  private _destroyAlert: Function;
+
+  constructor(private _adf: AlertDialogFactory) {
+  }
+
+  ngAfterViewInit() {
+    this._adf
+      .createAlertDialog(MyAlertDialogComponent, {message: 'This is just an example.'})
+      .then(({alertDialog, destroy}) => {
+        this._alert = alertDialog;
+        this._alert.show();
+        this._destroyAlert = destroy;
+      });
+  }
+
+  ngOnDestroy() {
+    this._destroyAlert();
+  }
+}
+
+```
+
+ビューの初期化が行われていない`constructor()`内で`createAlertDialog()`を呼び出すとエラーを引き起こすことに注意してください。
+
+## パラメータを受け取る
+
+`createAlertDialog()`の第二引数には、任意のデータを渡すことができます。
+
+```
+this._adf
+  .createAlertDialog(MyAlertDialogComponent, {message: 'This is just an example.'})
+  .then(({alertDialog, destroy}) => {
+    // ...
+  });
+```
+
+ここで渡したデータは、AlertDialogのコンポーネントのコンストラクタから取得することができます。
+
+```
+class MyAlertDialogComponent {
+  message = '';
+
+  constructor(params: Params) {
+    this.message = <string>params.at('message');
+  }
+}
+```
+
+## NgModule
+
+AlertDialogFactoryで読み込むコンポーネントは動的に読み込まれるものであるため、`NgModule`の`declarations`と`entryComponents`に追加することを忘れないでください。
+
+```
+@NgModule({
+  imports: [OnsenModule],
+  declarations: [AppComponent, MyAlertDialogComponent],
+  bootstrap: [AppComponent],
+  entryComponents: [MyAlertDialogComponent],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+class AppModule { }
+```
+
+## `<ons-dialog>`とDialogFactory
+
+アラートダイアログではなく、`<ons-page>`や`<ons-navigator>`などを埋め込めるダイアログを表示する場合には、`<ons-dialog>`を使います。
+
+`<ons-dialog>`をAngular 2で生成するには、DialogFactoryを使います。先ほど紹介したAlertDialogFactoryとほとんど同じ方法で使うことができます。
+
+```
+@Component({
+  template: `
+    <ons-dialog #dialog>
+      <div class="dialog-mask"></div>
+      <div class="dialog">
+        <div class="dialog-container" style="height: 200px;">
+          <ons-page>
+            <ons-toolbar>
+              <div class="center">Name</div>
+            </ons-toolbar>
+            <div class="content">
+              <div style="text-align: center">
+                <p>{{message}}</p>
+                <br>
+                <ons-button (click)="dialog.hide()">Close</ons-button>
+              </div>
+            </div>
+          </ons-page>
+        </div>
+      </div>
+    </ons-dialog>
+  `
+})
+class MyDialogComponent {
+  message = '';
+
+  constructor(params: Params) {
+    this.message = <string>params.at('message');
+  }
+}
+```
+
+DialogFactoryを通じてこのMyDialogComponentを初期化します。
+
+```
+export class AppComponent implements AfterViewInit, OnDestroy {
+  private _dialog: any;
+  private _destroyDialog: Function;
+
+  constructor(private _df: DialogFactory) {
+  }
+
+  ngAfterViewInit() {
+    this._df
+      .createDialog(MyDialogComponent, {message: 'This is just an example.'})
+      .then(({dialog, destroy}) => {
+        this._dialog = dialog;
+        this._destroyDialog = destroy;
+      });
+  }
+
+  ngOnDestroy() {
+    this._destroyDialog();
+  }
+}
+```
+
+AlertDialogの場合と同様に、初期化時に渡されるdestroy関数を終了時に呼び出すことを忘れないでください。
+
+-->

--- a/tutorial/angular2/reference/toolbar.html
+++ b/tutorial/angular2/reference/toolbar.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/typescript">
+    import {
+      Component,
+      OnsenModule,
+      NgModule,
+      CUSTOM_ELEMENTS_SCHEMA
+    } from 'ngx-onsenui';
+    import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+    import * as ons from 'onsenui';
+
+    @Component({
+      selector: 'app',
+      template: `
+      <ons-page>
+        <ons-toolbar>
+          <div class="center">{{title}}</div>
+          <div class="right">
+            <ons-toolbar-button>
+              <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
+            </ons-toolbar-button>
+          </div>
+        </ons-toolbar>
+        <div class="content">
+          <p style="text-align: center">
+            <ons-button (click)="alert()">Click me!</ons-button>
+          </p>
+        </div>
+      </ons-page>
+      `
+    })
+    export class AppComponent {
+      title:string = 'My app';
+
+      alert() {
+        ons.notification.alert('Hello, world!');
+      }
+    }
+
+    @NgModule({
+      imports: [OnsenModule],
+      declarations: [AppComponent],
+      bootstrap: [AppComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    })
+    class AppModule { }
+
+    platformBrowserDynamic().bootstrapModule(AppModule);
+  </script>
+</head>
+<body>
+  <app></app>
+</body>
+</html>
+
+<!-- info
+
+## The `ons-page` element
+
+Please refer to [ons-page element Reference](https://onsen.io/v2/docs/angular2/ons-page.html) for more details.
+
+For additional resources, please also see  [Guide for Angular 2+](https://onsen.io/v2/docs/guide/angular2).
+
+-->

--- a/tutorial/react/reference/alert-dialog.html
+++ b/tutorial/react/reference/alert-dialog.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var MyPage = React.createClass({
+      getInitialState: function() {
+        return {
+          dialogShown: false,
+          alertDialogShown: false,
+          toastShown: false,
+          items: [
+            {
+              title: 'Dialog',
+              fn: this.showDialog
+            },
+            {
+              title: 'Alert dialog',
+              fn: this.showAlertDialog
+            },
+            {
+              title: 'Toast',
+              fn: this.handleShow
+            },
+            {
+              title: 'Alert notification',
+              fn: () => ons.notification.alert('An error has occurred!')
+            },
+            {
+              title: 'Confirmation',
+              fn: () => ons.notification.confirm('Are you ready?')
+            },
+            {
+              title: 'Prompt',
+              fn: () => ons.notification.prompt('What\'s your name?')
+            }
+          ]
+        };
+      },
+
+      showDialog: function() {
+        this.setState({dialogShown: true});
+      },
+
+      hideDialog: function() {
+        this.setState({dialogShown: false});
+      },
+
+      showAlertDialog: function() {
+        this.setState({alertDialogShown: true});
+      },
+
+      hideAlertDialog: function() {
+        this.setState({alertDialogShown: false});
+      },
+
+      handleShow: function() {
+        this.setState({toastShown: true});
+      },
+
+      handleDismiss: function() {
+        this.setState({toastShown: false});
+      },
+
+      renderRow(row) {
+        return (
+          <Ons.ListItem key={row.title} tappable onClick={row.fn}>
+            {row.title}
+          </Ons.ListItem>
+        );
+      },
+
+      renderToolbar() {
+        return (
+          <Ons.Toolbar>
+            <div className='center'>Dialogs</div>
+          </Ons.Toolbar>
+        );
+      },
+
+      render: function() {
+        return (
+          <Ons.Page renderToolbar={this.renderToolbar}>
+            <Ons.List dataSource={this.state.items} renderRow={this.renderRow} />
+
+            <Ons.Dialog
+              isOpen={this.state.dialogShown}
+              isCancelable={true}
+              onCancel={this.hideDialog}>
+              <div style={{textAlign: 'center', margin: '20px'}}>
+                <p style={{opacity: 0.5}}>This is a dialog!</p>
+                <p>
+                  <Ons.Button onClick={this.hideDialog}>Close</Ons.Button>
+                </p>
+              </div>
+            </Ons.Dialog>
+
+            <Ons.AlertDialog
+              isOpen={this.state.alertDialogShown}
+              isCancelable={false}>
+              <div className='alert-dialog-title'>Warning!</div>
+              <div className='alert-dialog-content'>
+                An error has occurred!
+              </div>
+              <div className='alert-dialog-footer'>
+                <button onClick={this.hideAlertDialog} className='alert-dialog-button'>
+                  Cancel
+                </button>
+                <button onClick={this.hideAlertDialog} className='alert-dialog-button'>
+                  Ok
+                </button>
+              </div>
+            </Ons.AlertDialog>
+
+            <Ons.Toast isOpen={this.state.toastShown}>
+              <div className="message">
+                An error has occurred!
+              </div>
+              <button onClick={this.handleDismiss}>
+                Dismiss
+              </button>
+            </Ons.Toast>
+          </Ons.Page>
+        );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Dialogs
+
+There are three components used to show dialogs: `Dialog`, `AlertDialog` and `Toast`. The `Dialog` component is a general dialog where you can put any content. `AlertDialog` has some default styles that make it easy to show errors, warnings or questions to the user.
+And `Toast` is a message (with optional button) that does not stop the app flow.
+
+To show or hide the dialog the `isOpen` prop is used.
+
+```
+<Dialog isOpen={this.state.dialogShown}>
+  Hi!
+
+  <Button onClick={this.hideDialog.bind(this)}>
+    Close
+  </Button>
+</Dialog>
+```
+
+## Notification methods
+
+The `ons.notification` object contains some useful methods to easily show alerts, confirmation dialogs and prompts:
+
+* `ons.notification.alert(message, options)`
+* `ons.notificaiton.confirm(message, options)`
+* `ons.notification.prompt(message, options)`
+* `ons.notification.toast(message, options)`
+
+They all return a `Promise` object that can be used to handle the input from the user.
+
+```
+ons.notification.confirm('Are you ready?')
+  .then((response) => {
+    // Handle response.
+  });
+```
+
+-->

--- a/tutorial/react/reference/back-button.html
+++ b/tutorial/react/reference/back-button.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var index = 0;
+
+    var MyPage = React.createClass({
+      renderToolbar: function(route, navigator) {
+        const backButton = route.hasBackButton
+          ? <Ons.BackButton onClick={this.handleClick.bind(this, navigator)}>Back</Ons.BackButton>
+          : null;
+
+        return (
+          <Ons.Toolbar>
+            <div className='left'>{backButton}</div>
+            <div className='center'>{route.title}</div>
+          </Ons.Toolbar>
+        );
+      },
+
+      handleClick: function(navigator) {
+        ons.notification.confirm('Do you really want to go back?')
+          .then((response) => {
+            if (response === 1) {
+              navigator.popPage();
+            }
+          });
+      },
+
+      pushPage: function(navigator) {
+        navigator.pushPage({
+          title: `Another page ${index}`,
+          hasBackButton: true
+        });
+
+        index++;
+      },
+
+      renderPage: function(route, navigator) {
+        return (
+          <Ons.Page key={route.title} renderToolbar={this.renderToolbar.bind(this, route, navigator)}>
+            <section style={{margin: '16px', textAlign: 'center'}}>
+              <Ons.Button onClick={this.pushPage.bind(this, navigator)}>
+                Push Page
+              </Ons.Button>
+            </section>
+          </Ons.Page>
+        );
+      },
+
+      render: function() {
+        return (
+          <Ons.Navigator
+            swipeable
+            renderPage={this.renderPage}
+            initialRoute={{
+              title: 'First page',
+              hasBackButton: false
+            }}
+          />
+        );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Stack navigation
+
+The `Navigator` is a component that provides stack based navigation. It is a very common navigation pattern in mobile apps.
+
+After pushing a page to the top of the stack it will be displayed using transition animation. When the user goes back to the previous page the top page will be popped from the top of the stack and hidden with an corresponding transition animation.
+
+## Basic usage
+
+The `Navigator` maintains a stack of *route* objects. These objects can be arbitrary objects and are rendered into pages with the `renderPage` property. The `renderPage` property must be set to a function that returns a `Page` component.
+
+To push a new page on top of the stack, the `pushPage(route)` method is used. Similarly, a page is popped from the stack with the `popPage()` method.
+
+The stack must be initialized with either the `initialRoute` or `initialRouteStack`, depending on whether the the stack needs to be initialized with one or more pages.
+
+## The back button
+
+The `BackButton` component can be used to put a back button in the navigation bar. The component will automatically find the `Navigator` component and pop a page when pressed.
+
+```
+<Toolbar>
+  <div className='left'>
+    <BackButton>Back</BackButton>
+  </div>
+  <div className='center'>
+    Title
+  </div>
+</Toolbar>
+```
+
+## Customizing the animation
+
+There are several animations available for the `Navigator` component. To change the animation the `animation` property is used. Available animations are `slide`, `lift` and `fade`. Setting the property to `none` will make the transition instantly.
+
+It is also possible to customize the duration, delay and timing function of the animation using the `animationOptions` property.
+
+```
+<Navigator
+  initialRoute={...}
+  renderPage={...}
+  animation='fade'
+  animationOptions={{duration: 0.2, timing: 'ease-in'}}
+/>
+```
+
+For iOS' "swipe to pop" feature, add the `swipeable` prop. Note that this behavior is automatically removed on Android platforms unless `swipeable={'force'}` is specified.
+
+-->

--- a/tutorial/react/reference/checkbox.html
+++ b/tutorial/react/reference/checkbox.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+  var MyPage = React.createClass({
+  getInitialState: function() {
+    return {
+      vegetables: [
+        'Tomato',
+        'Cucumber',
+        'Onion',
+        'Eggplant',
+        'Cabbage'
+      ]
+    };
+  },
+
+  renderToolbar() {
+    return (
+      <Ons.Toolbar>
+        <div className='center'>Checkboxes</div>
+      </Ons.Toolbar>
+    );
+  },
+
+  renderCheckboxRow(row) {
+    return (
+      <Ons.ListItem key={row} tappable>
+        <label className='left'>
+          <Ons.Checkbox
+            inputId={`checkbox-${row}`}
+          />
+        </label>
+        <label htmlFor={`checkbox-${row}`} className='center'>
+          {row}
+        </label>
+      </Ons.ListItem>
+    )
+  },
+
+  render: function() {
+    return (
+      <Ons.Page renderToolbar={this.renderToolbar}>
+
+        <Ons.List
+          dataSource={this.state.vegetables}
+          renderRow={this.renderCheckboxRow}
+        />
+      </Ons.Page>
+    );
+  }
+});
+
+ons.ready(function() {
+  ReactDOM.render(<MyPage />, document.getElementById('app'));
+});
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Checkboxes and radio buttons
+
+`Checkbox` components are provided in Onsen UI:
+
+```
+<Checkbox checked={ this.state.checked } />
+```
+
+-->

--- a/tutorial/react/reference/input.html
+++ b/tutorial/react/reference/input.html
@@ -9,22 +9,14 @@
       getInitialState: function() {
         return {
           username: '',
-          password: '',
-          vegetables: [
-            'Tomato',
-            'Cucumber',
-            'Onion',
-            'Eggplant',
-            'Cabbage'
-          ],
-          selectedVegetable: 'Onion'
+          password: ''
         };
       },
-
+      
       renderToolbar() {
         return (
           <Ons.Toolbar>
-            <div className='center'>Form input</div>
+          <div className='center'>Form input</div>
           </Ons.Toolbar>
         );
       },
@@ -46,91 +38,39 @@
         this.setState({password: e.target.value});
       },
 
-      handleVegetableChange(vegetable) {
-        this.setState({selectedVegetable: vegetable});
-      },
-
-      renderCheckboxRow(row) {
-        return (
-          <Ons.ListItem key={row} tappable>
-            <label className='left'>
-              <Ons.Checkbox
-                inputId={`checkbox-${row}`}
-              />
-            </label>
-            <label htmlFor={`checkbox-${row}`} className='center'>
-              {row}
-            </label>
-          </Ons.ListItem>
-        )
-      },
-
-      renderRadioRow(row) {
-        return (
-          <Ons.ListItem key={row} tappable>
-            <label className='left'>
-              <Ons.Radio
-                inputId={`radio-${row}`}
-                checked={row === this.state.selectedVegetable}
-                onChange={this.handleVegetableChange.bind(this, row)}
-              />
-            </label>
-            <label htmlFor={`radio-${row}`} className='center'>
-              {row}
-            </label>
-          </Ons.ListItem>
-        )
-      },
-
       render: function() {
         return (
           <Ons.Page renderToolbar={this.renderToolbar}>
-            <section style={{textAlign: 'center'}}>
-              <p>
-                <Ons.SearchInput
-                  placeholder='Search' />
-              </p>
-              <p>
+          <section style={{textAlign: 'center'}}>
+            <p>
+              <Ons.Input
+                value={this.state.username}
+                onChange={this.handleUsernameChange}
+                modifier='underbar'
+                float
+                placeholder='Username' />
+                </p>
+                <p>
                 <Ons.Input
-                  value={this.state.username}
-                  onChange={this.handleUsernameChange}
-                  modifier='underbar'
-                  float
-                  placeholder='Username' />
-              </p>
-              <p>
-                <Ons.Input
-                  value={this.state.password}
-                  onChange={this.handlePasswordChange}
-                  modifier='underbar'
-                  type='password'
-                  float
-                  placeholder='Password' />
-              </p>
-              <p>
+                value={this.state.password}
+                onChange={this.handlePasswordChange}
+                modifier='underbar'
+                type='password'
+                float
+                placeholder='Password' />
+                </p>
+                <p>
                 <Ons.Button onClick={this.handleClick}>Sign in</Ons.Button>
-              </p>
-            </section>
+                </p>
+                </section>
+                </Ons.Page>
+              );
+            }
+          });
 
-            <Ons.List
-              dataSource={this.state.vegetables}
-              renderHeader={() => <Ons.ListHeader>Radio buttons</Ons.ListHeader>}
-              renderRow={this.renderRadioRow}
-            />
-
-            <Ons.List
-              dataSource={this.state.vegetables}
-              renderHeader={() => <Ons.ListHeader>Checkboxes</Ons.ListHeader>}
-              renderRow={this.renderCheckboxRow}
-            />
-          </Ons.Page>
-        );
-      }
-    });
-
-    ons.ready(function() {
-      ReactDOM.render(<MyPage />, document.getElementById('app'));
-    });
+          ons.ready(function() {
+            ReactDOM.render(<MyPage />, document.getElementById('app'));
+          });
   </script>
 </head>
 <body>
@@ -160,20 +100,4 @@ In Material Design the placeholder can be made to float using the `float` prop.
 />
 ```
 
-## Checkboxes and radio buttons
-
-`Checkbox` and `Radio` components are also provided in Onsen UI:
-
-```
-<Checkbox checked={ this.state.checked } />
-<Radio onChange={ this.handleRadioChange.bind(this) } />
-```
-
-## Search inputs
-
-Even though `Input` component can handle `type='search'`, an extra component is provided which implements search input styles:
-
-```
-<SearchInput placeholder='Search something' />
-```
 -->

--- a/tutorial/react/reference/notification.html
+++ b/tutorial/react/reference/notification.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var MyPage = React.createClass({
+      getInitialState: function() {
+        return {
+          items: [
+            {
+              title: 'Alert notification',
+              fn: () => ons.notification.alert('An error has occurred!')
+            },
+            {
+              title: 'Confirmation',
+              fn: () => ons.notification.confirm('Are you ready?')
+            },
+            {
+              title: 'Prompt',
+              fn: () => ons.notification.prompt('What\'s your name?')
+            },
+            {
+              title: 'Toast',
+              fn: () => ons.notification.toast('Toast')
+            }
+          ]
+        };
+      },
+
+      renderRow(row) {
+        return (
+          <Ons.ListItem key={row.title} tappable onClick={row.fn}>
+          {row.title}
+          </Ons.ListItem>
+        );
+      },
+
+      renderToolbar() {
+        return (
+          <Ons.Toolbar>
+          <div className='center'>Notifications</div>
+          </Ons.Toolbar>
+        );
+      },
+
+      render: function() {
+        return (
+          <Ons.Page renderToolbar={this.renderToolbar}>
+          <Ons.List dataSource={this.state.items} renderRow={this.renderRow} />
+          </Ons.Page>
+        );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Notification methods
+
+The `ons.notification` object contains some useful methods to easily show alerts, confirmation dialogs and prompts:
+
+* `ons.notification.alert(message, options)`
+* `ons.notification.confirm(message, options)`
+* `ons.notification.prompt(message, options)`
+* `ons.notification.toast(message, options)`
+
+They all return a `Promise` object that can be used to handle the input from the user.
+
+```
+ons.notification.confirm('Are you ready?')
+  .then((response) => {
+    // Handle response.
+  });
+```
+
+-->

--- a/tutorial/react/reference/progress-circular.html
+++ b/tutorial/react/reference/progress-circular.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var MyPage = React.createClass({
+      getInitialState: function() {
+        return {progress: 0};
+      },
+
+      renderToolbar() {
+        return (
+          <Ons.Toolbar>
+            <div className='center'>Progress</div>
+          </Ons.Toolbar>
+        );
+      },
+
+      componentDidMount: function() {
+        this.interval = setInterval(() => {
+          let progress = this.state.progress;
+
+          if (progress === 100) {
+            clearInterval(this.interval);
+            return;
+          }
+
+          progress++;
+          this.setState({progress: progress});
+
+        }, 40);
+      },
+
+      componentWillUnmount: function() {
+        if (this.interval) {
+          clearInterval(this.interval);
+        }
+      },
+
+      render: function() {
+        return (
+          <Ons.Page renderToolbar={this.renderToolbar}>
+            <Ons.ProgressBar value={this.state.progress} />
+
+            <section style={{margin: '16px'}}>
+              <p>
+                Progress: {this.state.progress}%
+              </p>
+
+              <p>
+                <Ons.ProgressBar value={20} />
+              </p>
+
+              <p>
+                <Ons.ProgressBar value={40} secondaryValue={80} />
+              </p>
+
+              <p>
+                <Ons.ProgressBar indeterminate />
+              </p>
+
+              <p>
+                <Ons.ProgressCircular value={20} />
+                <Ons.ProgressCircular value={40} secondaryValue={80} />
+                <Ons.ProgressCircular indeterminate />
+              </p>
+
+            </section>
+          </Ons.Page>
+        );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+## Progress
+
+There are two components for indicating progress: `ProgressBar` and `ProgressCircular`. As the names imply, the `ProgressBar` displays a linear progress bar while the `ProgressCircular` displays a circular progress indicator.
+
+They have the ability to show the current progress or a looping animation in cases where the current progress is not known.
+
+Both components implement the same props.
+
+To change the progress the `value` property is used. It should be a value between `0` and `100`.
+
+```
+<ProgressBar value={this.state.currentProgress} />
+<ProgressCircular value={this.state.currentProgress} />
+```
+
+## Secondary value
+
+It is sometimes necessary to display two different values in the same progress indicator. An example could be an app that streams a video. The progress bar could show both how much of the video has elapsed in addition to how much of the video that has been buffered.
+
+To do this the `secondaryValue` property can be used.
+
+```
+<ProgressBar
+  value={this.state.elapsed}
+  secondaryValue={this.state.buffered}
+/>
+```
+
+## Indeterminate mode
+
+There is also an `indeterminate` property which makes the component ignore both the `value` and `secondaryValue` properties. Instead, it show a looping animation. This can be useful for cases where the total progress is unknown, e.g. when waiting for some data to arrive.
+
+```
+<ProgressBar indeterminate />
+```
+-->

--- a/tutorial/react/reference/radio.html
+++ b/tutorial/react/reference/radio.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+  var MyPage = React.createClass({
+    getInitialState: function() {
+      return {
+        vegetables: [
+          'Tomato',
+          'Cucumber',
+          'Onion',
+          'Eggplant',
+          'Cabbage'
+        ],
+        selectedVegetable: 'Onion'
+      };
+    },
+
+    renderToolbar() {
+      return (
+        <Ons.Toolbar>
+        <div className='center'>Radio buttons</div>
+        </Ons.Toolbar>
+      );
+    },
+
+    handleVegetableChange(vegetable) {
+      this.setState({selectedVegetable: vegetable});
+    },
+
+    renderRadioRow(row) {
+      return (
+        <Ons.ListItem key={row} tappable>
+        <label className='left'>
+          <Ons.Radio
+            inputId={`radio-${row}`}
+            checked={row === this.state.selectedVegetable}
+            onChange={this.handleVegetableChange.bind(this, row)}
+            />
+            </label>
+            <label htmlFor={`radio-${row}`} className='center'>
+            {row}
+            </label>
+            </Ons.ListItem>
+          )
+        },
+
+        render: function() {
+          return (
+            <Ons.Page renderToolbar={this.renderToolbar}>
+            <Ons.List
+            dataSource={this.state.vegetables}
+            renderRow={this.renderRadioRow}
+            />
+            </Ons.Page>
+          );
+        }
+      });
+
+      ons.ready(function() {
+        ReactDOM.render(<MyPage />, document.getElementById('app'));
+      });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Radio buttons
+
+`Radio` components are provided in Onsen UI:
+
+```
+<Radio onChange={ this.handleRadioChange.bind(this) } />
+```
+
+-->

--- a/tutorial/react/reference/search-input.html
+++ b/tutorial/react/reference/search-input.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var MyPage = React.createClass({
+      getInitialState: function() {
+        return {};
+      },
+
+      renderToolbar() {
+        return (
+          <Ons.Toolbar>
+          <div className='center'>Search input</div>
+          </Ons.Toolbar>
+        );
+      },
+
+      render: function() {
+        return (
+          <Ons.Page renderToolbar={this.renderToolbar}>
+          <section style={{textAlign: 'center'}}>
+            <p>
+              <Ons.SearchInput
+                placeholder='Search' />
+                </p>
+                </section>
+                </Ons.Page>
+              );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Search inputs
+
+Even though `Input` component can handle `type='search'`, an extra component is provided which implements search input styles:
+
+```
+<SearchInput placeholder='Search something' />
+```
+
+-->

--- a/tutorial/react/reference/toast.html
+++ b/tutorial/react/reference/toast.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var MyPage = React.createClass({
+      getInitialState: function() {
+        return {
+          dialogShown: false,
+          alertDialogShown: false,
+          toastShown: false,
+          items: [
+            {
+              title: 'Dialog',
+              fn: this.showDialog
+            },
+            {
+              title: 'Alert dialog',
+              fn: this.showAlertDialog
+            },
+            {
+              title: 'Toast',
+              fn: this.handleShow
+            },
+            {
+              title: 'Alert notification',
+              fn: () => ons.notification.alert('An error has occurred!')
+            },
+            {
+              title: 'Confirmation',
+              fn: () => ons.notification.confirm('Are you ready?')
+            },
+            {
+              title: 'Prompt',
+              fn: () => ons.notification.prompt('What\'s your name?')
+            }
+          ]
+        };
+      },
+
+      showDialog: function() {
+        this.setState({dialogShown: true});
+      },
+
+      hideDialog: function() {
+        this.setState({dialogShown: false});
+      },
+
+      showAlertDialog: function() {
+        this.setState({alertDialogShown: true});
+      },
+
+      hideAlertDialog: function() {
+        this.setState({alertDialogShown: false});
+      },
+
+      handleShow: function() {
+        this.setState({toastShown: true});
+      },
+
+      handleDismiss: function() {
+        this.setState({toastShown: false});
+      },
+
+      renderRow(row) {
+        return (
+          <Ons.ListItem key={row.title} tappable onClick={row.fn}>
+            {row.title}
+          </Ons.ListItem>
+        );
+      },
+
+      renderToolbar() {
+        return (
+          <Ons.Toolbar>
+            <div className='center'>Dialogs</div>
+          </Ons.Toolbar>
+        );
+      },
+
+      render: function() {
+        return (
+          <Ons.Page renderToolbar={this.renderToolbar}>
+            <Ons.List dataSource={this.state.items} renderRow={this.renderRow} />
+
+            <Ons.Dialog
+              isOpen={this.state.dialogShown}
+              isCancelable={true}
+              onCancel={this.hideDialog}>
+              <div style={{textAlign: 'center', margin: '20px'}}>
+                <p style={{opacity: 0.5}}>This is a dialog!</p>
+                <p>
+                  <Ons.Button onClick={this.hideDialog}>Close</Ons.Button>
+                </p>
+              </div>
+            </Ons.Dialog>
+
+            <Ons.AlertDialog
+              isOpen={this.state.alertDialogShown}
+              isCancelable={false}>
+              <div className='alert-dialog-title'>Warning!</div>
+              <div className='alert-dialog-content'>
+                An error has occurred!
+              </div>
+              <div className='alert-dialog-footer'>
+                <button onClick={this.hideAlertDialog} className='alert-dialog-button'>
+                  Cancel
+                </button>
+                <button onClick={this.hideAlertDialog} className='alert-dialog-button'>
+                  Ok
+                </button>
+              </div>
+            </Ons.AlertDialog>
+
+            <Ons.Toast isOpen={this.state.toastShown}>
+              <div className="message">
+                An error has occurred!
+              </div>
+              <button onClick={this.handleDismiss}>
+                Dismiss
+              </button>
+            </Ons.Toast>
+          </Ons.Page>
+        );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Dialogs
+
+There are three components used to show dialogs: `Dialog`, `AlertDialog` and `Toast`. The `Dialog` component is a general dialog where you can put any content. `AlertDialog` has some default styles that make it easy to show errors, warnings or questions to the user.
+And `Toast` is a message (with optional button) that does not stop the app flow.
+
+To show or hide the dialog the `isOpen` prop is used.
+
+```
+<Dialog isOpen={this.state.dialogShown}>
+  Hi!
+
+  <Button onClick={this.hideDialog.bind(this)}>
+    Close
+  </Button>
+</Dialog>
+```
+
+## Notification methods
+
+The `ons.notification` object contains some useful methods to easily show alerts, confirmation dialogs and prompts:
+
+* `ons.notification.alert(message, options)`
+* `ons.notificaiton.confirm(message, options)`
+* `ons.notification.prompt(message, options)`
+* `ons.notification.toast(message, options)`
+
+They all return a `Promise` object that can be used to handle the input from the user.
+
+```
+ons.notification.confirm('Are you ready?')
+  .then((response) => {
+    // Handle response.
+  });
+```
+
+-->

--- a/tutorial/react/reference/toolbar.html
+++ b/tutorial/react/reference/toolbar.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    var MyPage = React.createClass({
+      handleClick: function() {
+        ons.notification.alert('Hello world!');
+      },
+
+      renderToolbar: function() {
+        return (
+          <Ons.Toolbar>
+            <div className='center'>My app</div>
+            <div className='right'>
+            <Ons.ToolbarButton>
+              <Ons.Icon icon='ion-navicon, material:md-menu'></Ons.Icon>
+            </Ons.ToolbarButton>
+            </div>
+          </Ons.Toolbar>
+        );
+      },
+
+      render: function() {
+        return (
+          <Ons.Page renderToolbar={this.renderToolbar}>
+            <p style={{textAlign: 'center'}}>
+              <Ons.Button onClick={this.handleClick}>
+                Click me!
+              </Ons.Button>
+            </p>
+          </Ons.Page>
+        );
+      }
+    });
+
+    ons.ready(function() {
+      ReactDOM.render(<MyPage />, document.getElementById('app'));
+    });
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## The `<Page>` component
+
+The `<Page>` component serves as the main view of a screen in an app. It covers the whole screen and is used as a container for the other components.
+
+```
+<Page>
+  Content goes here
+</Page>
+```
+
+## Adding a toolbar
+
+The `Toolbar` component displays a navigation bar on the top of a `Page` component. It is separated into three sections (left, center and right) in order to let the buttons and title be layouted a beautiful way.
+
+A toolbar is displayed on the screen by return the `Toolbar` component in the `renderToolbar` property of the `Page` element. To layout the content the `left`, `center` and `right` classes are used.
+
+```
+<Page
+  renderToolbar={() =>
+    <Toolbar>
+      <div className='left'>Left</div>
+      <div className='center'>Center</div>
+      <div className='right'>Right</div>
+    </Toolbar>
+  }
+/>
+```
+
+## The `Ons` object
+
+The React extension exports an object called `Ons` where all the components are attached. So to create a button you can use the `Ons.Button` component.
+
+```
+<Ons.Button>Click me!</Ons.Button>
+```
+
+It also contains a bunch of other components such as:
+
+* `Ons.Page`
+* `Ons.Toolbar`
+* `Ons.Navigator`
+* ...and many more.
+
+## Defining event handlers
+
+In React some event handlers are exposed as props. One of those is the `onClick` prop which can be used with any component.
+
+```
+<Ons.Button onClick={this.handleClick}>Click me!</Ons.Button>
+```
+
+When the button is clicked the `this.handleClick` method is called.
+
+## Showing a notification
+
+The `Ons` object contains all the components so it's different from the `ons` object which is provided by the core Onsen UI library.
+
+Just like in normal Onsen UI apps you can show dialogs using the `ons.notification` methods:
+
+```
+ons.notification.alert('Hello world!');
+```
+
+-->

--- a/tutorial/vanilla/reference/alert-dialog.html
+++ b/tutorial/vanilla/reference/alert-dialog.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    var showAlertDialog = function() {
+      document
+        .getElementById('dialog-1')
+        .show();
+    };
+
+    var showTemplateAlertDialog = function() {
+      var dialog = document.getElementById('dialog-2');
+
+      if (dialog) {
+        dialog.show();
+      } else {
+        ons.createAlertDialog('dialog.html')
+          .then(function(dialog) {
+            dialog.show();
+          });
+      }
+    };
+
+    var showNotificationAlertDialog = function() {
+      ons.notification.alert('This dialog was created with ons.notification');
+    }
+
+    var hideDialog = function(id) {
+      document
+        .getElementById(id)
+        .hide();
+    };
+  </script>
+</head>
+
+<body>
+  <ons-page>
+    <ons-button onclick="showAlertDialog()">Alert 1</ons-button>
+    <ons-button onclick="showTemplateAlertDialog()">Alert 2</ons-button>
+    <ons-button onclick="showNotificationAlertDialog()">Alert 3</ons-button>
+  </ons-page>
+
+  <ons-alert-dialog id="dialog-1">
+    <div class="alert-dialog-title">Alert</div>
+    <div class="alert-dialog-content">
+      Alert content
+    </div>
+    <div class="alert-dialog-footer">
+      <button class="alert-dialog-button" onclick="hideDialog('dialog-1')">Cancel</button>
+      <button class="alert-dialog-button" onclick="hideDialog('dialog-1')">OK</button>
+    </div>
+  </ons-alert-dialog>
+
+  <template id="dialog.html">
+  <ons-alert-dialog id="dialog-2">
+    <div class="alert-dialog-title">Alert</div>
+    <div class="alert-dialog-content">
+        This dialog was created from a template
+    </div>
+    <div class="alert-dialog-footer">
+      <ons-button class="alert-dialog-button" onclick="hideDialog('dialog-2')">Close</ons-button>
+    </div>
+  </ons-alert-dialog>
+</template>
+</body>
+
+</html>
+
+<!-- info
+
+## Alert dialogs
+
+Alert dialogs are defined using the `<ons-alert-dialog>` tag.
+Alert dialogs work exactly like normal dialogs but they require some additional markup. With this element you can create a beautifully styled dialog without any additional CSS.
+
+```
+<ons-alert-dialog id="dialog-1">
+  <div class="alert-dialog-title">Warning!</div>
+  <div class="alert-dialog-content">
+    An error has occurred!
+  </div>
+  <div class="alert-dialog-footer">
+    <button class="alert-dialog-button">Cancel</button>
+    <button class="alert-dialog-button">OK</button>
+  </div>
+</ons-alert-dialog>
+```
+
+Alert dialogs are hidden by default and usually attached as direct children of the `<body>` tag.
+
+## Displaying an alert dialog
+
+To display an alert dialog you need to get a reference to the element and execute the `show(options)` method.
+
+```
+document
+  .getElementById('dialog-1')
+  .show();
+```
+
+It is hidden with the `hide(options)` method.
+
+## Loading from a template
+
+Another way to use alert dialogs is with the `ons.createAlertDialog(template)` utility function. The dialog needs to be defined as a template and the function returns a `Promise` that resolves to the dialog element.
+
+```
+<template id="dialog.html">
+  <ons-alert-dialog>
+    This dialog is defined as a template.
+  </ons-alert-dialog>
+</template>
+```
+
+```
+ons
+  .createAlertDialog('dialog.html')
+  .then(function(dialog) {
+    dialog.show();
+  });
+```
+
+## The `cancelable` attribute
+
+`<ons-alert-dialog>` supports the `cancelable` attribute. This enables hiding the dialog by tapping outside of it or by pressing the back button on Android devices.
+
+```
+<ons-alert-dialog cancelable>
+  This dialog can be cancelled!
+</ons-alert-dialog>
+```
+
+Try adding the `cancelable` attribute to the dialog to see how it works.
+
+## Notification
+
+Another way to display alert dialogs is with the `ons.notification` methods:
+
+* `ons.notification.alert(options)`
+
+This method returns a `Promise`.
+
+```
+ons
+  .notification.prompt({message: 'What is your name?'})
+  .then(function(name) {
+    ons.notification.alert('Hello ' + name);
+  });
+```
+
+
+-->

--- a/tutorial/vanilla/reference/back-button.html
+++ b/tutorial/vanilla/reference/back-button.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    document.addEventListener('init', function(event) {
+      var page = event.target;
+
+      if (page.id === 'page1') {
+        page.querySelector('#push-button').onclick = function() {
+          document.querySelector('#myNavigator').pushPage('page2.html', {data: {title: 'Page 2'}});
+        };
+      } else if (page.id === 'page2') {
+        page.querySelector('ons-toolbar .center').innerHTML = page.data.title;
+      }
+    });
+  </script>
+</head>
+<body>
+  <ons-navigator swipeable id="myNavigator" page="page1.html"></ons-navigator>
+
+  <template id="page1.html">
+    <ons-page id="page1">
+      <ons-toolbar>
+        <div class="center">Page 1</div>
+      </ons-toolbar>
+
+      <p>This is the first page.</p>
+
+      <ons-button id="push-button">Push page</ons-button>
+    </ons-page>
+  </template>
+
+  <template id="page2.html">
+    <ons-page id="page2">
+      <ons-toolbar>
+        <div class="left"><ons-back-button>Page 1</ons-back-button></div>
+        <div class="center"></div>
+      </ons-toolbar>
+
+      <p>This is the second page.</p>
+    </ons-page>
+  </template>
+</body>
+</html>
+
+<!-- info
+
+## Going back
+
+To go back to a previous page use the `<ons-back-button>` element. It can be added to the left side of the toolbar and renders as an arrow:
+
+```
+<ons-toolbar>
+  <div class="left">
+    <ons-back-button>Back</ons-back-button>
+  </div>
+</ons-toolbar>
+```
+
+It will automatically find the Navigator element and trigger a `popPage()` call so there is no need to attach any click handlers to it.
+
+The `popPage()` method of `<ons-navigator>` can also be used directly instead of `<ons-back-button>`.
+
+
+-->

--- a/tutorial/vanilla/reference/checkbox.html
+++ b/tutorial/vanilla/reference/checkbox.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+  <script>
+  </script>
+</head>
+
+<body>
+  <ons-page>
+    <ons-list>
+      <ons-list-item tappable>
+        <label class="left">
+          <ons-checkbox input-id="check-1"></ons-checkbox>
+        </label>
+        <label for="check-1" class="center">
+          Apple
+        </label>
+      </ons-list-item>
+      <ons-list-item tappable>
+        <label class="left">
+          <ons-checkbox input-id="check-2"></ons-checkbox>
+        </label>
+        <label for="check-2" class="center">
+          Banana
+        </label>
+      </ons-list-item>
+    </ons-list>
+  </ons-page>
+</body>
+
+</html>
+
+<!-- info
+
+## Checkboxes
+
+Checkboxes are defined using the `<ons-checkbox>` element. The element works almost exactly as when you use a normal `<input type="checkbox">` element.
+
+```
+<ons-checkbox value="something" checked></ons-checkbox>
+```
+
+## Inner input element
+
+For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
+
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+
+```
+<label for="username">Username</label>
+<ons-input input-id="username"></ons-input>
+```
+
+This work with any input in Onsen UI such as checkboxes, radios, etc.
+
+-->

--- a/tutorial/vanilla/reference/dialog.html
+++ b/tutorial/vanilla/reference/dialog.html
@@ -6,98 +6,69 @@
   <title>Onsen UI App</title>
 
   <script>
-    var showDialog = function (id) {
+    var showDialog = function() {
       document
-        .getElementById(id)
+        .getElementById('dialog-1')
         .show();
     };
 
-    var hideDialog = function (id) {
-      document
-        .getElementById(id)
-        .hide();
-    };
-
-    var fromTemplate = function () {
-      var dialog = document.getElementById('dialog-3');
+    var showTemplateDialog = function() {
+      var dialog = document.getElementById('dialog-2');
 
       if (dialog) {
         dialog.show();
-      }
-      else {
+      } else {
         ons.createDialog('dialog.html')
-          .then(function (dialog) {
+          .then(function(dialog) {
             dialog.show();
           });
       }
     };
 
-    function toggleToast() {
-      document.querySelector('ons-toast').toggle();
+    var showNotificationDialog = function() {
+      ons.notification.confirm('This dialog was created with ons.notification');
     }
+
+    var hideDialog = function(id) {
+      document
+        .getElementById(id)
+        .hide();
+    };
   </script>
 </head>
 
 <body>
   <ons-page>
-    <ons-toolbar>
-      <div class="center">Dialogs</div>
-    </ons-toolbar>
+  <ons-button onclick="showDialog()">Dialog 1</ons-button>
+  <ons-button onclick="showTemplateDialog()">Dialog 2</ons-button>
+  <ons-button onclick="showNotificationDialog()">Dialog 3</ons-button>
+</ons-page>
 
-    <ons-list>
-      <ons-list-header>Showing dialogs</ons-list-header>
-      <ons-list-item tappable onclick="showDialog('dialog-1')">Simple dialog</ons-list-item>
-      <ons-list-item tappable onclick="showDialog('dialog-2')">Alert dialog</ons-list-item>
-      <ons-list-item tappable onclick="fromTemplate()">From template</ons-list-item>
-      <ons-list-item tappable onclick="toggleToast()">Toggle Toast</ons-list-item>
-      <ons-list-header>Notifications</ons-list-header>
-      <ons-list-item tappable onclick="ons.notification.alert('Hello, world')">Alert</ons-list-item>
-      <ons-list-item tappable onclick="ons.notification.confirm({message: 'Are you ready?'})">Confirmation</ons-list-item>
-      <ons-list-item tappable onclick="ons.notification.prompt({message: 'What is your name?'})">Prompt</ons-list-item>
-      <ons-list-item tappable onclick="ons.notification.toast({message: 'Enjoy Onsen UI', timeout: 2000})">Toast</ons-list-item>
-    </ons-list>
-  </ons-page>
+<ons-dialog id="dialog-1">
+  <div style="text-align: center; padding: 10px;">
+    <p>
+      This is a dialog
+    </p>
 
-  <ons-dialog id="dialog-1">
+    <p>
+      <ons-button onclick="hideDialog('dialog-1')">Close</ons-button>
+    </p>
+  </div>
+</ons-dialog>
+
+<template id="dialog.html">
+  <ons-dialog id="dialog-3">
     <div style="text-align: center; padding: 10px;">
       <p>
-        This is a dialog.
+        This dialog was created from a template
       </p>
 
       <p>
-        <ons-button onclick="hideDialog('dialog-1')">Close</ons-button>
+        <ons-button onclick="hideDialog('dialog-3')">Close</ons-button>
       </p>
     </div>
   </ons-dialog>
-
-  <ons-alert-dialog id="dialog-2">
-    <div class="alert-dialog-title">Warning!</div>
-    <div class="alert-dialog-content">
-      An error has occurred!
-    </div>
-    <div class="alert-dialog-footer">
-      <button class="alert-dialog-button" onclick="hideDialog('dialog-2')">Cancel</button>
-      <button class="alert-dialog-button" onclick="hideDialog('dialog-2')">OK</button>
-    </div>
-  </ons-alert-dialog>
-
-  <template id="dialog.html">
-    <ons-dialog id="dialog-3">
-      <div style="text-align: center; padding: 10px;">
-        <p>
-          This dialog was created from a template.
-        </p>
-
-        <p>
-          <ons-button onclick="hideDialog('dialog-3')">Close</ons-button>
-        </p>
-      </div>
-    </ons-dialog>
-  </template>
-
-  <ons-toast>
-    This is an Onsen Toast!<button>Hoge</button>
-  </ons-toast>
+</template>
 </body>
 
 </html>
@@ -106,7 +77,7 @@
 
 ## Dialogs
 
-Normal dialogs are defined using the `<ons-dialog>` tag. There is also an `<ons-alert-dialog>` tag that is used to display alert dialogs and an `<ons-toast>` one for toast messages.
+Normal dialogs are defined using the `<ons-dialog>` tag.
 
 ```
 <ons-dialog id="dialog-1">
@@ -114,7 +85,7 @@ Normal dialogs are defined using the `<ons-dialog>` tag. There is also an `<ons-
 </ons-dialog>
 ```
 
-The dialogs are hidden by default and usually attached as direct childs of the `<body>` tag.
+Dialogs are hidden by default and usually attached as direct children of the `<body>` tag.
 
 ## Displaying a dialog
 
@@ -148,26 +119,9 @@ ons
   });
 ```
 
-## Alert dialogs
-
-Alert dialogs work exactly like normal dialogs but they require some additional markup. With this element you can create a beautifully styled dialog without any additional CSS.
-
-```
-<ons-alert-dialog>
-  <div class="alert-dialog-title">Warning!</div>
-  <div class="alert-dialog-content">
-    An error has occurred!
-  </div>
-  <div class="alert-dialog-footer">
-    <button class="alert-dialog-button">Cancel</button>
-    <button class="alert-dialog-button">OK</button>
-  </div>
-</ons-alert-dialog>
-```
-
 ## The `cancelable` attribute
 
-The `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` support the `cancelable` attribute. This enables hiding the dialog by tapping outside of it or by pressing the back button on Android devices.
+`<ons-dialog>` supports the `cancelable` attribute. This enables hiding the dialog by tapping outside of it or by pressing the back button on Android devices.
 
 ```
 <ons-dialog cancelable>
@@ -175,7 +129,7 @@ The `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` support the `cancelab
 </ons-dialog>
 ```
 
-Try adding the `cancelable` attribute to one of the dialogs to see how it works.
+Try adding the `cancelable` attribute to the dialog to see how it works.
 
 ## Notification
 

--- a/tutorial/vanilla/reference/input.html
+++ b/tutorial/vanilla/reference/input.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>Onsen UI App</title>
@@ -11,23 +12,15 @@
 
       if (username === 'bob' && password === 'secret') {
         ons.notification.alert('Congratulations!');
-      }
-      else {
+      } else {
         ons.notification.alert('Incorrect username or password.');
       }
     };
   </script>
 </head>
+
 <body>
   <ons-page>
-    <ons-toolbar>
-      <div class="center">Input</div>
-    </ons-toolbar>
-
-    <p style="text-align: center; margin-top: 10px;">
-      <ons-search-input placeholder="Search"></ons-search-input>
-    </p>
-
     <div style="text-align: center; margin-top: 30px;">
       <p>
         <ons-input id="username" modifier="underbar" placeholder="Username" float></ons-input>
@@ -39,48 +32,9 @@
         <ons-button onclick="login()">Sign in</ons-button>
       </p>
     </div>
-
-    <ons-list>
-      <ons-list-header>Checkboxes</ons-list-header>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-checkbox input-id="check-1"></ons-checkbox>
-        </label>
-        <label for="check-1" class="center">
-          Apple
-        </label>
-      </ons-list-item>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-checkbox input-id="check-2"></ons-checkbox>
-        </label>
-        <label for="check-2" class="center">
-          Banana
-        </label>
-      </ons-list-item>
-    </ons-list>
-
-    <ons-list>
-      <ons-list-header>Radio buttons</ons-list-header>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-radio name="color" input-id="radio-1" checked></ons-radio>
-        </label>
-        <label for="radio-1" class="center">
-          Red
-        </label>
-      </ons-list-item>
-      <ons-list-item tappable>
-        <label class="left">
-          <ons-radio name="color" input-id="radio-2"></ons-radio>
-        </label>
-        <label for="radio-2" class="center">
-          Blue
-        </label>
-      </ons-list-item>
-    </ons-list>
   </ons-page>
 </body>
+
 </html>
 
 <!-- info
@@ -115,46 +69,12 @@ The label is defined with the `placeholder` attribute and to activate the animat
 </ons-input>
 ```
 
-## Search input
-
-Even though `ons-input` supports `type="search"`, Onsen UI provides an extra element `ons-search-input` that styles the input as a real search bar:
-
-```html
-<ons-search-input placeholder="Search something"></ons-search-input>
-```
-
-As usual, any attribute for `<input>` element works for the search input (except `type` which is fixed to `search`).
-
-## Checkboxes
-
-Checkboxes are defined using the `<ons-checkbox>` element. The element works almost exactly as when you use a normal `<input type="checkbox">` element.
-
-```
-<ons-checkbox value="something" checked></ons-checkbox>
-```
-
-## Radio buttons
-
-Radio buttons are defined using the `<ons-radio>` element.
-
-```
-<ons-radio checked></ons-radio>
-```
-
-To create a group of radio buttons the `name` attribute is used:
-
-```
-<ons-radio name="group" value="first"></ons-radio>
-<ons-radio name="group" value="second"></ons-radio>
-```
-
-This will enable switching between radio buttons.
-
 ## Inner input element
 
 For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
 
-Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element.
+This is done using the `input-id` attribute.
 
 ```
 <label for="username">Username</label>

--- a/tutorial/vanilla/reference/input.html
+++ b/tutorial/vanilla/reference/input.html
@@ -39,7 +39,7 @@
 
 <!-- info
 
-## Form inputs
+## Text input
 
 In Onsen UI text input is provided by the `<ons-input>` tag. It works exactly like the normal `<input>` tag but with some small differences.
 

--- a/tutorial/vanilla/reference/notification.html
+++ b/tutorial/vanilla/reference/notification.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    var showAlert = function() {
+      ons.notification.alert('Alert!');
+    };
+
+    var showConfirm = function() {
+      ons.notification.confirm('Confirm!')
+        .then(function(buttonIndex) {
+          var message = buttonIndex === -1 ? 'Cancelled!' : 'Ok!';
+          ons.notification.alert(message);
+        })
+    };
+
+    var showPrompt = function() {
+      ons.notification.prompt('Prompt!')
+        .then(function(input) {
+          var message = input ? 'Entered: ' + input : 'Entered nothing!';
+          ons.notification.alert(message);
+        });
+    };
+
+    var showToast = function() {
+      ons.notification.toast('Toast!', {
+        timeout: 2000
+      });
+    };
+  </script>
+</head>
+
+<body>
+  <ons-page>
+    <ons-button onclick="showAlert()">Alert</ons-button>
+    <ons-button onclick="showConfirm()">Confirm</ons-button>
+    <ons-button onclick="showPrompt()">Prompt</ons-button>
+    <ons-button onclick="showToast()">Toast</ons-button>
+  </ons-page>
+</body>
+
+</html>
+
+<!-- info
+
+## Notification
+
+Dialogs can be displayed with the `ons.notification` methods:
+
+* `ons.notification.alert(options)`
+* `ons.notification.confirm(options)`
+* `ons.notification.prompt(options)`
+* `ons.notification.toast(options)`
+
+These methods all return a `Promise`. For the `confirm` it resolves to the index of the button pressed and for the `prompt` it resolves to the user input.
+
+```
+ons
+  .notification.prompt({message: 'What is your name?'})
+  .then(function(name) {
+    ons.notification.alert('Hello ' + name);
+  });
+```
+
+The `<ons-dialog>`, `<ons-alert-dialog>` and `<ons-toast>` tags can also be used instead of `ons.notification`.
+
+-->

--- a/tutorial/vanilla/reference/notification.html
+++ b/tutorial/vanilla/reference/notification.html
@@ -12,10 +12,6 @@
 
     var showConfirm = function() {
       ons.notification.confirm('Confirm!')
-        .then(function(buttonIndex) {
-          var message = buttonIndex === -1 ? 'Cancelled!' : 'Ok!';
-          ons.notification.alert(message);
-        })
     };
 
     var showPrompt = function() {

--- a/tutorial/vanilla/reference/page.html
+++ b/tutorial/vanilla/reference/page.html
@@ -99,36 +99,4 @@ Alternatively, lifecycle hooks are also provided for those who prefer a more com
 
 `ons.getScriptPage()` returns the page element of the current `script` tag. It cannot be used in any other context.
 
-## Adding a toolbar
-
-Most mobile apps have a toolbar at the top containing a header text and maybe some buttons.
-
-In Onsen UI this is achieved using the `<ons-toolbar>` element. It is divided into three sections that are defined using the HTML classes `left`, `center` and `right`.
-
-```html
-<ons-toolbar>
-  <div class="left">
-    <!-- left section -->
-  </div>
-  <div class="center">
-    <!-- title -->
-  </div>
-  <div class="right">
-    <!-- right section -->
-  </div>
-</ons-toolbar>
-```
-
-## The `ons` object
-
-Onsen UI not only provides custom elements, it also provides an object called `ons` with a lot of useful functions attached to it. In this example we are using `ons.notification.alert` to show an alert dialog.
-
-There are also `confirm` and `prompt` methods available to show other types of dialogs. You can try replacing the click handler with the following code to get another type of dialog:
-
-```javascript
-ons.notification.confirm({message: 'Are you ready?'});
-```
-
-We will take a look at other types of dialogs in a later section.
-
 -->

--- a/tutorial/vanilla/reference/progress-circular.html
+++ b/tutorial/vanilla/reference/progress-circular.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+  </script>
+</head>
+<body>
+  <ons-page>
+    <ons-toolbar>
+      <div class="center">Progress</div>
+    </ons-toolbar>
+
+    <div style="margin: 20px auto; width: 320px;">
+      <p>Loading stuff...</p>
+      <ons-progress-circular value="10"></ons-progress-circular>
+    </div>
+
+    <ons-progress-circular value="20" secondary-value="50"></ons-progress-circular>
+    <ons-progress-circular indeterminate></ons-progress-circular>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Progress
+
+`ons-progress-circular` takes two different values in `value` and `secondary-value` attributes. `indeterminate` attribute is also available.
+
+Onsen UI also provides a progress bar element, `ons-progress-bar`.
+
+-->

--- a/tutorial/vanilla/reference/progress.html
+++ b/tutorial/vanilla/reference/progress.html
@@ -21,9 +21,6 @@
     </div>
 
     <ons-progress-bar indeterminate></ons-progress-bar>
-    <ons-progress-circular value="10"></ons-progress-circular>
-    <ons-progress-circular value="20" secondary-value="50"></ons-progress-circular>
-    <ons-progress-circular indeterminate></ons-progress-circular>
   </ons-page>
 </body>
 </html>
@@ -32,8 +29,8 @@
 
 ## Progress
 
-Onsen UI provide two different progress element: `<ons-progress-bar>` and `ons-progress-circular`.
+`<ons-progress-bar>` takes two different values in `value` and `secondary-value` attributes. `indeterminate` attribute is also available.
 
-These elements takes two different values in `value` and `secondary-value` attributes. `indeterminate` attribute is also available.
+Onsen UI also provides a circular progress element, `ons-progress-circular`.
 
 -->

--- a/tutorial/vanilla/reference/radio.html
+++ b/tutorial/vanilla/reference/radio.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+  </script>
+</head>
+<body>
+  <ons-page>
+    <ons-list>
+      <ons-list-item tappable>
+        <label class="left">
+          <ons-radio name="color" input-id="radio-1" checked></ons-radio>
+        </label>
+        <label for="radio-1" class="center">
+          Red
+        </label>
+      </ons-list-item>
+      <ons-list-item tappable>
+        <label class="left">
+          <ons-radio name="color" input-id="radio-2"></ons-radio>
+        </label>
+        <label for="radio-2" class="center">
+          Blue
+        </label>
+      </ons-list-item>
+    </ons-list>
+  </ons-page>
+</body>
+</html>
+
+<!-- info
+
+## Radio buttons
+
+Radio buttons are defined using the `<ons-radio>` element.
+
+```
+<ons-radio checked></ons-radio>
+```
+
+To create a group of radio buttons the `name` attribute is used:
+
+```
+<ons-radio name="group" value="first"></ons-radio>
+<ons-radio name="group" value="second"></ons-radio>
+```
+
+This will enable switching between radio buttons.
+
+## Inner input element
+
+For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
+
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+
+```
+<label for="username">Username</label>
+<ons-input input-id="username"></ons-input>
+```
+
+This work with any input in Onsen UI such as checkboxes, radios, etc.
+
+-->

--- a/tutorial/vanilla/reference/search-input.html
+++ b/tutorial/vanilla/reference/search-input.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    var search = function(input) {
+      ons.notification.alert('Searched for "' + input.value + '"');
+    };
+  </script>
+</head>
+
+<body>
+  <ons-page>
+    <p style="text-align: center; margin-top: 10px;">
+      <ons-search-input placeholder="Search" onchange="search(this)"></ons-search-input>
+    </p>
+  </ons-page>
+</body>
+
+</html>
+
+<!-- info
+
+## Search input
+
+Even though `ons-input` supports `type="search"`, Onsen UI provides an extra element `ons-search-input` that styles the input as a real search bar:
+
+```html
+<ons-search-input placeholder="Search something"></ons-search-input>
+```
+
+As usual, any attribute for `<input>` element works for the search input (except `type` which is fixed to `search`).
+
+## Inner input element
+
+For normal input elements is possible to define a `<label>` tab with the `for` attribute to link it to an input element.
+
+Unfortunately this does not work with custom elements like `<ons-label>` so in order to do it we need to set the `id` attribute of the inner input element. This is done using the `input-id` attribute.
+
+```
+<label for="username">Username</label>
+<ons-input input-id="username"></ons-input>
+```
+
+This work with any input in Onsen UI such as checkboxes, radios, etc.
+
+-->

--- a/tutorial/vanilla/reference/toast.html
+++ b/tutorial/vanilla/reference/toast.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    var toggleToast = function() {
+      document.getElementById('toast-1').toggle();
+    };
+
+    var notificationToast = function() {
+      ons.notification.toast('This is another toast', {
+        timeout: 2000
+      });
+    };
+  </script>
+</head>
+
+<body>
+  <ons-page>
+    <ons-button onclick="toggleToast()">Toggle toast 1</ons-button>
+    <ons-button onclick="notificationToast()">Show toast 2</ons-button>
+  </ons-page>
+
+  <ons-toast id="toast-1">
+    This is a toast
+  </ons-toast>
+</body>
+
+</html>
+
+<!-- info
+
+## Toasts
+
+Toasts are defined using the `<ons-toast>` tag.
+
+```
+<ons-toast id="dialog-1">
+  This is a toast!
+</ons-toast>
+```
+
+Toasts are hidden by default and usually attached as direct children of the `<body>` tag.
+
+## Displaying a toast
+
+To display a toast you need to get a reference to the element and execute the `show(options)` method.
+
+```
+document
+  .getElementById('toast-1')
+  .show();
+```
+
+It is hidden with the `hide(options)` method.
+
+Toasts can be toggled with the `toggle(options)` method.
+
+## The `cancelable` attribute
+
+`<ons-toast>` supports the `cancelable` attribute. This enables hiding the dialog by tapping outside of it or by pressing the back button on Android devices.
+
+```
+<ons-toast cancelable>
+  This toast can be cancelled!
+</ons-toast>
+```
+
+Try adding the `cancelable` attribute to the toast to see how it works.
+
+## Notification
+
+Another way to display toasts is with the `ons.notification` method:
+
+* `ons.notification.toast(options)`
+
+This method returns a `Promise`.
+
+```
+ons
+  .notification.prompt({message: 'What is your name?'})
+  .then(function(name) {
+    ons.notification.toast('Hello ' + name);
+  });
+```
+
+-->

--- a/tutorial/vanilla/reference/toolbar.html
+++ b/tutorial/vanilla/reference/toolbar.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script>
+    document.addEventListener('init', function(event) {
+      var page = event.target;
+      if (page.matches('#helloworld-page')) {
+        page.querySelector('ons-toolbar .center').innerHTML = 'My app';
+      }
+    });
+  </script>
+</head>
+
+<body>
+  <ons-page id="helloworld-page">
+    <ons-toolbar>
+      <div class="center"></div>
+      <div class="right">
+        <ons-toolbar-button>
+          <ons-icon icon="ion-navicon, material:md-menu"></ons-icon>
+        </ons-toolbar-button>
+      </div>
+    </ons-toolbar>
+  </ons-page>
+</body>
+
+</html>
+
+<!-- info
+
+## Adding a toolbar
+
+Most mobile apps have a toolbar at the top containing a header text and maybe some buttons.
+
+In Onsen UI this is achieved using the `<ons-toolbar>` element. It is divided into three sections that are defined using the HTML classes `left`, `center` and `right`.
+
+```html
+<ons-toolbar>
+  <div class="left">
+    <!-- left section -->
+</div>
+<div class="center">
+  <!-- title -->
+</div>
+<div class="right">
+  <!-- right section -->
+</div>
+</ons-toolbar>
+```
+
+Buttons can be added to the toolbar with the `<ons-toolbar-button>` element.
+
+-->

--- a/tutorial/vue/reference/alert-dialog.html
+++ b/tutorial/vue/reference/alert-dialog.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    new Vue({
+      el: '#app',
+      template: '#main',
+      data() {
+        return {
+          dialogVisible: false,
+          alertDialog1Visible: false,
+          alertDialog2Visible: false
+        };
+      }
+    });
+  </script>
+</head>
+<body>
+  <template id="main">
+    <v-ons-page>
+      <v-ons-toolbar>
+        <div class="center">Dialogs</div>
+      </v-ons-toolbar>
+
+      <v-ons-list>
+        <v-ons-list-header>Notifications</v-ons-list-header>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.alert('Hello, world!')"
+          >
+          <div class="center">
+            Alert
+          </div>
+        </v-ons-list-item>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.confirm('Are you ready?')"
+          >
+          <div class="center">
+            Confirmation
+          </div>
+        </v-ons-list-item>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.prompt('What is your name?')"
+          >
+          <div class="center">
+            Prompt
+          </div>
+        </v-ons-list-item>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.toast('Hello, world!', {timeout: 2000})"
+        >
+          <div class="center">
+            Toast
+          </div>
+        </v-ons-list-item>
+
+        <v-ons-list-header>Components</v-ons-list-header>
+        <v-ons-list-item tappable
+          @click="dialogVisible = true"
+        >
+          <div class="center">
+            Simple Dialog
+          </div>
+        </v-ons-list-item>
+
+        <v-ons-list-item tappable
+          @click="alertDialog1Visible = true"
+        >
+          <div class="center">
+            Alert Dialog (slots)
+          </div>
+        </v-ons-list-item>
+
+        <v-ons-list-item tappable
+          @click="alertDialog2Visible = true"
+        >
+          <div class="center">
+            Alert Dialog (props)
+          </div>
+        </v-ons-list-item>
+
+      </v-ons-list>
+
+      <v-ons-dialog cancelable
+        :visible.sync="dialogVisible"
+      >
+        <p style="text-align: center">Lorem ipsum</p>
+      </v-ons-dialog>
+
+      <v-ons-alert-dialog modifier="rowfooter"
+        :visible.sync="alertDialog1Visible"
+      >
+        <span slot="title">Title slots</span>
+        Lorem ipsum
+        <template slot="footer">
+          <div class="alert-dialog-button" @click="alertDialog1Visible = false">Cancel</div>
+          <div class="alert-dialog-button" @click="alertDialog1Visible = false">Ok</div>
+        </template>
+      </v-ons-alert-dialog>
+
+      <v-ons-alert-dialog modifier="rowfooter"
+        :title="'Title props'"
+        :footer="{
+          Cancel: () => alertDialog2Visible = false,
+          Ok: () => alertDialog2Visible = false
+        }"
+        :visible.sync="alertDialog2Visible"
+      >
+        Lorem ipsum
+      </v-ons-alert-dialog>
+
+    </v-ons-page>
+  </template>
+
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Dialogs
+
+There are three components used to show dialogs: `VOnsDialog`, `VOnsAlertDialog` and `VOnsToast`. The `VOnsDialog` component is a general dialog where you can put any content. The `VOnsAlertDialog` has some default styles that make it easy to show errors, warnings or questions to the user.
+And `VOnsToast` is a message (with optional button) that does not stop the app flow.
+
+To show or hide the dialog the `visible` prop is used.
+
+```html
+<v-ons-dialog cancelable
+  :visible.sync="show"
+>
+  Hi!
+
+  <v-ons-button @click="show = false">
+    Close
+  </v-ons-button>
+</v-ons-dialog>
+```
+
+An `update:visible` event is fired when the user interacts with the component (taps the background mask). Use this event to refresh the value of `visible` prop. Vue's `sync` modifier can also be used.
+
+## Notification methods
+
+The `$ons.notification` object contains some useful methods to easily show alerts, confirmation dialogs and prompts:
+
+1.
+```javascript
+$ons.notification.alert(message, options)
+```
+2.
+```javascript
+$ons.notification.confirm(message, options)
+```
+3.
+```javascript
+$ons.notification.prompt(message, options)
+```
+4.
+```javascript
+$ons.notification.toast(message, options)
+```
+
+They all return a `Promise` object that can be used to handle the input from the user.
+
+```javascript
+$ons.notification.confirm('Are you ready?')
+  .then((response) => {
+    // Handle response.
+  });
+```
+
+## Custom alerts
+
+`VOnsAlertDialog` allows to create custom alerts with optional inputs, methods or anything else. We can pass all the information with props:
+
+```html
+<v-ons-alert-dialog modifier="rowfooter"
+  :title="myTitle"
+  :footer="{
+    Cancel: () => isVisible = false,
+    Ok: () => isVisible = false
+  }"
+  :visible.sync="isVisible"
+>
+
+  Content here
+</v-ons-alert-dialog>
+```
+
+For higher control, it is also possible to use slots (can be combined with props):
+
+```html
+<v-ons-alert-dialog modifier="rowfooter"
+  :visible.sync="isVisible"
+>
+  <span slot="title">Title</span>
+
+  Content here
+
+  <template slot="footer">
+    <button class="alert-dialog-button" @click="isVisible = false">Cancel</button>
+    <button class="alert-dialog-button" @click="isVisible = false">Ok</button>
+  </template>
+</v-ons-alert-dialog>
+```
+
+The optional `rowfooter` modifier forces the buttons to be displayed on a single row rather than a column.
+
+-->

--- a/tutorial/vue/reference/back-button.html
+++ b/tutorial/vue/reference/back-button.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    const page2 = {
+      key: 'page2',
+      template: '#page2'
+    };
+
+    const page1 = {
+      key: 'page1',
+      template: '#page1',
+      methods: {
+        push() {
+          this.$emit('push-page', page2);
+        }
+      }
+    };
+
+    new Vue({
+      el: '#app',
+      template: '#main',
+      data() {
+        return {
+          pageStack: [page1]
+        };
+      }
+    });
+  </script>
+</head>
+<body>
+  <template id="main">
+    <v-ons-navigator swipeable
+      :page-stack="pageStack"
+      @push-page="pageStack.push($event)"
+    ></v-ons-navigator>
+  </template>
+
+  <template id="page1">
+    <v-ons-page>
+      <v-ons-toolbar>
+        <div class="center">Page 1</div>
+      </v-ons-toolbar>
+      <p style="text-align: center">
+        This is the first page
+        <v-ons-button @click="push">Push Page 2</v-ons-button>
+      </p>
+    </v-ons-page>
+  </template>
+
+  <template id="page2">
+    <v-ons-page>
+      <v-ons-toolbar>
+        <div class="left">
+          <v-ons-back-button>Page 1</v-ons-back-button>
+        </div>
+        <div class="center">Page 2</div>
+      </v-ons-toolbar>
+      <p style="text-align: center">This is the second page</p>
+    </v-ons-page>
+  </template>
+
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Stack navigation
+
+The `VOnsNavigator` is a component that provides stack based navigation. It is a very common navigation pattern in mobile apps.
+
+After pushing a page to the top of the stack, it will be displayed using transition animation. When the user goes back to the previous page the top page will be popped from the top of the stack and hidden with a corresponding transition animation.
+
+## Basic usage
+
+An array of `VOnsPage` components must be passed as a prop to `VOnsNavigator`.
+
+```html
+<v-ons-navigator :page-stack="[p1, p2, p3]"></v-ons-navigator>
+```
+
+Whenever the page stack is modified, `VOnsNavigator` will perform the corresponding transition. Pushing or popping multiple pages at once is allowed, although only 1 animation will be performed.
+
+Any action will throw corresponding `prepush`, `postpush`, `prepop` and `postpop` events.
+
+## Modifying the stack
+
+The page stack can be modified from any place where the array is accessible either by calling array methods (`push`, `pop`, `splice`...) or assigning a new value (`pageStack = [...pageStack, newPage]`). This "pageStack" can be created at any component level but it must be passed to `v-ons-navigator` as a prop.
+
+For example, if there is a `VOnsSplitter` as a parent component of `VOnsNavigator` that also needs to modify the stack, the splitter will create the array and then pass it to the child navigator. This way, both components (parent splitter and child navigator) will be able to modify the stack.
+
+In order to push a new page from the current one (sibling pages), pages must have access to the stack array as well. There are many ways to achieve this sort of component communication in Vue. First one, we can define custom actions as event listeners:
+
+```html
+<v-ons-navigator :page-stack="pageStack"
+  @push-page="pageStack.push($event)"
+  @replace-page="pageStack.pop(); pageStack.push($event)"
+></v-ons-navigator>
+```
+
+`VOnsNavigator` sets custom listeners (i.e. anything except `@prepush`, `@postpush`, `@prepop` and `@postpop`) directly to its child pages. This way, you can name your events however you like and do any action you want. With the previous example, we can push a new page from any existing page as follows:
+
+```js
+// import newPage from ...
+this.$emit('push-page', newPage);
+```
+
+Optionally, `v-for` directive can be used to iterate over the array and provide direct children. This way, it is possible to pass down extra props to the pages if necessary. This is useful, for example, if we want to pass the page stack down to every page instead of using custom events.
+
+```html
+<v-ons-navigator :page-stack="pageStack">
+  <component :v-for="page in pageStack" :is="page"
+    :page-stack="pageStack"
+    :extra-prop=""
+    @customEvent=""
+  ></component>
+</v-ons-navigator>
+```
+
+If our pages implement `pageStack` prop, it will now be possible to run `this.pageStack.push(newPage)`, for example. Note that passing `pageStack` prop to `VOnsNavigator` is still mandatory since it will be used by the `VOnsBackButton` component.
+
+## The back button
+
+The `VOnsBackButton` component can be used to display a back button in the navigation bar. By default, this component automatically finds its parent `VOnsNavigator` component and pops a page when pressed. However, this default behavior can be overriden by running `event.preventDefault` in a click handler (or using Vue's `.prevent` shorthand modifier):
+
+```html
+<v-ons-back-button @click.prevent="pageStack.splice(1, pageStack.length - 1)"></v-ons-back-button>
+```
+
+The previous code resets the pageStack to its first page instance instead of popping 1 single page. It assumes `pageStack` variable exists in the current context.
+
+## Customizing the animation
+
+There are several animations available for `VOnsNavigator` component. It can be specified with the `options.animation` prop. Available animations are `slide`, `lift` and `fade`. Setting the property to `none` will make the transition instantly.
+
+It is also possible to customize the duration, delay and timing function of the animation using the `options.animationOptions` property.
+
+```
+<v-ons-navigator
+  :options="{
+    animation: 'fade',
+    animationOptions: {duration: 0.2, timing: 'ease-in'}
+  }"
+>
+</v-ons-navigator>
+```
+
+For iOS' "swipe to pop" feature, add the `swipeable` prop. Note that this behavior is automatically removed on Android platforms unless `swipeable="force"` is specified.
+
+-->

--- a/tutorial/vue/reference/checkbox.html
+++ b/tutorial/vue/reference/checkbox.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>Onsen UI App</title>
@@ -10,52 +11,56 @@
       template: '#main',
       data() {
         return {
-          name: ''
+          colors: ['Red', 'Green', 'Blue'],
+          checkedColors: ['Green', 'Blue']
         };
       }
     });
   </script>
 </head>
+
 <body>
   <template id="main">
   <v-ons-page>
     <v-ons-toolbar>
-      <div class="center">Text input</div>
+      <div class="center">Checkboxes</div>
     </v-ons-toolbar>
 
     <v-ons-list>
-      <v-ons-list-item>
-        <div class="center">
-          <v-ons-input placeholder="Input your name" float
-            v-model="name"
+      <v-ons-list-header>
+        Checkboxes - {{checkedColors}}
+      </v-ons-list-header>
+      <v-ons-list-item v-for="(color, $index) in colors" :key="color" tappable>
+        <label class="left">
+          <v-ons-checkbox
+            :input-id="'checkbox-' + $index"
+            :value="color"
+            v-model="checkedColors"
           >
-          </v-ons-input>
-        </div>
+          </v-ons-checkbox>
+        </label>
+        <label class="center" :for="'checkbox-' + $index">
+          {{ color }}
+        </label>
       </v-ons-list-item>
-      <v-ons-list-item>
-        <div class="right">
-          Hello {{ name || 'anonymous' }}!
-        </div>
-      </v-ons-list-item>
+
     </v-ons-list>
   </v-ons-page>
-  </template>
+</template>
 
   <div id="app"></div>
+
 </body>
+
 </html>
 
 <!-- info
 
-## Text input
+## Checkboxes
 
-Text input elements are created using the `VOnsInput` component. It works almost exactly the same as a normal `<input>` tag.
-
-This component implements a `type` attribute to choose the type of the input. Default is `text` but it also admits `password`, `number`, etc. The only exception are checkboxes and radio buttons, which have corresponding components, `VOnsCheckbox` and `VOnsRadio`.
+Checkboxes are created with the `VOnsCheckbox` component. It works almost exactly the same way as a normal `<input type="checkbox">` tag.
 
 An attribute `input-id` is provided to set the ID of the inner native element. This is useful for `HTMLLabel` elements: `<label for="some-inner-input">`.
-
-For the text-like inputs, in Material Design the placeholder can be made to float using the `float` prop.
 
 ## Using v-model
 

--- a/tutorial/vue/reference/dialog.html
+++ b/tutorial/vue/reference/dialog.html
@@ -155,7 +155,7 @@ $ons.notification.alert(message, options)
 ```
 2.
 ```javascript
-$ons.notificaiton.confirm(message, options)
+$ons.notification.confirm(message, options)
 ```
 3.
 ```javascript

--- a/tutorial/vue/reference/notification.html
+++ b/tutorial/vue/reference/notification.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    new Vue({
+      el: '#app',
+      template: '#main'
+    });
+  </script>
+</head>
+<body>
+  <template id="main">
+  <v-ons-page>
+    <v-ons-toolbar>
+      <div class="center">Notifications</div>
+    </v-ons-toolbar>
+
+    <v-ons-list>
+      <v-ons-list-item
+        tappable
+        @click="$ons.notification.alert('Hello, world!')"
+        >
+        <div class="center">
+          Alert
+        </div>
+      </v-ons-list-item>
+      <v-ons-list-item
+        tappable
+        @click="$ons.notification.confirm('Are you ready?')"
+        >
+        <div class="center">
+          Confirmation
+        </div>
+      </v-ons-list-item>
+      <v-ons-list-item
+        tappable
+        @click="$ons.notification.prompt('What is your name?')"
+        >
+        <div class="center">
+          Prompt
+        </div>
+      </v-ons-list-item>
+      <v-ons-list-item
+        tappable
+        @click="$ons.notification.toast('Hello, world!', {timeout: 2000})"
+      >
+        <div class="center">
+          Toast
+        </div>
+      </v-ons-list-item>
+    </v-ons-list>
+  </v-ons-page>
+</template>
+
+<div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Notification methods
+
+The `$ons.notification` object contains some useful methods to easily show alerts, confirmation dialogs and prompts:
+
+1.
+```javascript
+$ons.notification.alert(message, options)
+```
+2.
+```javascript
+$ons.notification.confirm(message, options)
+```
+3.
+```javascript
+$ons.notification.prompt(message, options)
+```
+4.
+```javascript
+$ons.notification.toast(message, options)
+```
+
+They all return a `Promise` object that can be used to handle the input from the user.
+
+```javascript
+$ons.notification.confirm('Are you ready?')
+  .then((response) => {
+    // Handle response.
+  });
+```
+
+Notifications can also be created using `VOnsDialog`, `VOnsAlertDialog` and `VOnsToast` instead of `$ons.notification`.
+
+-->

--- a/tutorial/vue/reference/progress-circular.html
+++ b/tutorial/vue/reference/progress-circular.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    new Vue({
+      el: '#app',
+      template: '#main',
+      data() {
+        return {
+          progress: 0,
+          intervalID: 0
+        };
+      },
+      mounted() {
+        this.intervalID = setInterval(() => {
+          if (this.progress === 100) {
+            clearInterval(this.intervalID);
+            return;
+          }
+
+          this.progress++;
+        }, 40);
+      }
+    });
+  </script>
+</head>
+<body>
+  <template id="main">
+    <v-ons-page>
+      <v-ons-toolbar>
+        <div class="center">Progress</div>
+      </v-ons-toolbar>
+
+      <v-ons-progress-bar :value="progress"></v-ons-progress-bar>
+
+      <section style="margin: 16px">
+        <p>
+          Progress: {{ progress }}%
+        </p>
+
+        <p>
+          <v-ons-progress-bar value="20"></v-ons-progress-bar>
+        </p>
+
+        <p>
+          <v-ons-progress-bar value="40" secondary-value="80"></v-ons-progress-bar>
+        </p>
+
+        <p>
+          <v-ons-progress-bar indeterminate></v-ons-progress-bar>
+        </p>
+
+        <p>
+          <v-ons-progress-circular value="20"></v-ons-progress-circular>
+          <v-ons-progress-circular value="40" secondary-value="80"></v-ons-progress-circular>
+          <v-ons-progress-circular indeterminate></v-ons-progress-circular>
+        </p>
+      </section>
+
+    </v-ons-page>
+  </template>
+
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Progress
+
+There are two components for indicating progress: `VOnsProgressBar` and `VOnsProgressCircular`. As the names imply, the `VOnsProgressBar` displays a linear progress bar while the `VOnsProgressCircular` displays a circular progress indicator.
+
+They have the ability to show the current progress or a looping animation in cases where the current progress is not known.
+
+Both components implement the same props.
+
+To change the progress the `value` property is used. It should be a value between `0` and `100`.
+
+```
+<v-ons-progress-bar :value="currentProgress"></v-ons-progress-bar>
+<v-ons-progress-circular :value="currentProgress" /></v-ons-progress-circular>
+```
+
+## Secondary value
+
+It is sometimes necessary to display two different values in the same progress indicator. An example could be an app that streams a video. The progress bar could show both how much of the video has elapsed in addition to how much of the video that has been buffered.
+
+To do this the `secondaryValue` property can be used.
+
+```
+<v-ons-progress-bar
+  :value="elapsed"
+  :secondaryValue="buffered"
+>
+</v-ons-progress-bar>
+```
+
+## Indeterminate mode
+
+There is also an `indeterminate` property which makes the component ignore both the `value` and `secondaryValue` properties. Instead, it show a looping animation. This can be useful for cases where the total progress is unknown, e.g. when waiting for some data to arrive.
+
+```
+<v-ons-progress-bar indeterminate></v-ons-progress-bar>
+```
+-->

--- a/tutorial/vue/reference/radio.html
+++ b/tutorial/vue/reference/radio.html
@@ -56,7 +56,7 @@
 
 <!-- info
 
-## Form input
+## Radio buttons
 
 Radio button elements are created using the `VOnsRadio` component. It works almost exactly the same as a normal `<input type="radio">` tag.
 

--- a/tutorial/vue/reference/radio.html
+++ b/tutorial/vue/reference/radio.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>Onsen UI App</title>
@@ -10,31 +11,38 @@
       template: '#main',
       data() {
         return {
-          name: ''
+          vegetables: ['Apples', 'Bananas', 'Oranges'],
+          selectedVegetable: 'Bananas'
         };
       }
     });
   </script>
 </head>
+
 <body>
   <template id="main">
   <v-ons-page>
     <v-ons-toolbar>
-      <div class="center">Text input</div>
+      <div class="center">Radio buttons</div>
     </v-ons-toolbar>
 
     <v-ons-list>
-      <v-ons-list-item>
-        <div class="center">
-          <v-ons-input placeholder="Input your name" float
-            v-model="name"
+      <v-ons-list-item v-for="(vegetable, $index) in vegetables" :key="vegetable" tappable>
+        <label class="left">
+          <v-ons-radio
+            :input-id="'radio-' + $index"
+            :value="vegetable"
+            v-model=" selectedVegetable"
           >
-          </v-ons-input>
-        </div>
+          </v-ons-radio>
+        </label>
+        <label :for="'radio-' + $index" class="center">
+          {{ vegetable }}
+        </label>
       </v-ons-list-item>
       <v-ons-list-item>
-        <div class="right">
-          Hello {{ name || 'anonymous' }}!
+        <div class="center">
+          I love {{ selectedVegetable }}!
         </div>
       </v-ons-list-item>
     </v-ons-list>
@@ -43,19 +51,16 @@
 
   <div id="app"></div>
 </body>
+
 </html>
 
 <!-- info
 
-## Text input
+## Form input
 
-Text input elements are created using the `VOnsInput` component. It works almost exactly the same as a normal `<input>` tag.
-
-This component implements a `type` attribute to choose the type of the input. Default is `text` but it also admits `password`, `number`, etc. The only exception are checkboxes and radio buttons, which have corresponding components, `VOnsCheckbox` and `VOnsRadio`.
+Radio button elements are created using the `VOnsRadio` component. It works almost exactly the same as a normal `<input type="radio">` tag.
 
 An attribute `input-id` is provided to set the ID of the inner native element. This is useful for `HTMLLabel` elements: `<label for="some-inner-input">`.
-
-For the text-like inputs, in Material Design the placeholder can be made to float using the `float` prop.
 
 ## Using v-model
 

--- a/tutorial/vue/reference/search-input.html
+++ b/tutorial/vue/reference/search-input.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    new Vue({
+      el: '#app',
+      template: '#main',
+      data() {
+        return {
+          query: ''
+        };
+      }
+    });
+  </script>
+</head>
+
+<body>
+  <template id="main">
+  <v-ons-page>
+    <v-ons-toolbar>
+      <div class="center">Search input</div>
+    </v-ons-toolbar>
+    <p>
+      <v-ons-search-input placeholder="Search something" v-model="query"></v-ons-search-input>
+    </p>
+    <p>Query: {{ query }}</p>
+  </v-ons-page>
+  </template>
+
+  <div id="app"></div>
+</body>
+
+</html>
+
+<!-- info
+
+## Search input
+
+Search input elements are created using the `VOnsSearchInput` component. It works almost exactly the same as a normal `<input type="search">` tag.
+
+An attribute `input-id` is provided to set the ID of the inner native element. This is useful for `HTMLLabel` elements: `<label for="some-inner-input">`.
+
+In Material Design the placeholder can be made to float using the `float` prop.
+
+## Using v-model
+
+Search input are compatible with `v-model` directive. The only exception are modifiers (as of `vue@2.3`). There is, however, a workaround for `lazy` modifier:
+
+```html
+<v-ons-input v-model="something" model-event="change"></v-ons-input>
+```
+
+This will use `change` event instead of `input` when updating `v-model`.
+-->

--- a/tutorial/vue/reference/toast.html
+++ b/tutorial/vue/reference/toast.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    new Vue({
+      el: '#app',
+      template: '#main',
+      data() {
+        return {
+          dialogVisible: false,
+          alertDialog1Visible: false,
+          alertDialog2Visible: false
+        };
+      }
+    });
+  </script>
+</head>
+<body>
+  <template id="main">
+    <v-ons-page>
+      <v-ons-toolbar>
+        <div class="center">Dialogs</div>
+      </v-ons-toolbar>
+
+      <v-ons-list>
+        <v-ons-list-header>Notifications</v-ons-list-header>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.alert('Hello, world!')"
+          >
+          <div class="center">
+            Alert
+          </div>
+        </v-ons-list-item>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.confirm('Are you ready?')"
+          >
+          <div class="center">
+            Confirmation
+          </div>
+        </v-ons-list-item>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.prompt('What is your name?')"
+          >
+          <div class="center">
+            Prompt
+          </div>
+        </v-ons-list-item>
+        <v-ons-list-item
+          tappable
+          @click="$ons.notification.toast('Hello, world!', {timeout: 2000})"
+        >
+          <div class="center">
+            Toast
+          </div>
+        </v-ons-list-item>
+
+        <v-ons-list-header>Components</v-ons-list-header>
+        <v-ons-list-item tappable
+          @click="dialogVisible = true"
+        >
+          <div class="center">
+            Simple Dialog
+          </div>
+        </v-ons-list-item>
+
+        <v-ons-list-item tappable
+          @click="alertDialog1Visible = true"
+        >
+          <div class="center">
+            Alert Dialog (slots)
+          </div>
+        </v-ons-list-item>
+
+        <v-ons-list-item tappable
+          @click="alertDialog2Visible = true"
+        >
+          <div class="center">
+            Alert Dialog (props)
+          </div>
+        </v-ons-list-item>
+
+      </v-ons-list>
+
+      <v-ons-dialog cancelable
+        :visible.sync="dialogVisible"
+      >
+        <p style="text-align: center">Lorem ipsum</p>
+      </v-ons-dialog>
+
+      <v-ons-alert-dialog modifier="rowfooter"
+        :visible.sync="alertDialog1Visible"
+      >
+        <span slot="title">Title slots</span>
+        Lorem ipsum
+        <template slot="footer">
+          <div class="alert-dialog-button" @click="alertDialog1Visible = false">Cancel</div>
+          <div class="alert-dialog-button" @click="alertDialog1Visible = false">Ok</div>
+        </template>
+      </v-ons-alert-dialog>
+
+      <v-ons-alert-dialog modifier="rowfooter"
+        :title="'Title props'"
+        :footer="{
+          Cancel: () => alertDialog2Visible = false,
+          Ok: () => alertDialog2Visible = false
+        }"
+        :visible.sync="alertDialog2Visible"
+      >
+        Lorem ipsum
+      </v-ons-alert-dialog>
+
+    </v-ons-page>
+  </template>
+
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## Dialogs
+
+There are three components used to show dialogs: `VOnsDialog`, `VOnsAlertDialog` and `VOnsToast`. The `VOnsDialog` component is a general dialog where you can put any content. The `VOnsAlertDialog` has some default styles that make it easy to show errors, warnings or questions to the user.
+And `VOnsToast` is a message (with optional button) that does not stop the app flow.
+
+To show or hide the dialog the `visible` prop is used.
+
+```html
+<v-ons-dialog cancelable
+  :visible.sync="show"
+>
+  Hi!
+
+  <v-ons-button @click="show = false">
+    Close
+  </v-ons-button>
+</v-ons-dialog>
+```
+
+An `update:visible` event is fired when the user interacts with the component (taps the background mask). Use this event to refresh the value of `visible` prop. Vue's `sync` modifier can also be used.
+
+## Notification methods
+
+The `$ons.notification` object contains some useful methods to easily show alerts, confirmation dialogs and prompts:
+
+1.
+```javascript
+$ons.notification.alert(message, options)
+```
+2.
+```javascript
+$ons.notification.confirm(message, options)
+```
+3.
+```javascript
+$ons.notification.prompt(message, options)
+```
+4.
+```javascript
+$ons.notification.toast(message, options)
+```
+
+They all return a `Promise` object that can be used to handle the input from the user.
+
+```javascript
+$ons.notification.confirm('Are you ready?')
+  .then((response) => {
+    // Handle response.
+  });
+```
+
+## Custom alerts
+
+`VOnsAlertDialog` allows to create custom alerts with optional inputs, methods or anything else. We can pass all the information with props:
+
+```html
+<v-ons-alert-dialog modifier="rowfooter"
+  :title="myTitle"
+  :footer="{
+    Cancel: () => isVisible = false,
+    Ok: () => isVisible = false
+  }"
+  :visible.sync="isVisible"
+>
+
+  Content here
+</v-ons-alert-dialog>
+```
+
+For higher control, it is also possible to use slots (can be combined with props):
+
+```html
+<v-ons-alert-dialog modifier="rowfooter"
+  :visible.sync="isVisible"
+>
+  <span slot="title">Title</span>
+
+  Content here
+
+  <template slot="footer">
+    <button class="alert-dialog-button" @click="isVisible = false">Cancel</button>
+    <button class="alert-dialog-button" @click="isVisible = false">Ok</button>
+  </template>
+</v-ons-alert-dialog>
+```
+
+The optional `rowfooter` modifier forces the buttons to be displayed on a single row rather than a column.
+
+-->

--- a/tutorial/vue/reference/toolbar.html
+++ b/tutorial/vue/reference/toolbar.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Onsen UI App</title>
+
+  <script type="text/babel">
+    new Vue({
+      el: '#app',
+      template: '#main',
+      data() {
+        return {
+          title: 'My app'
+        };
+      }
+    });
+  </script>
+</head>
+<body>
+  <template id="main">
+    <v-ons-page>
+      <v-ons-toolbar>
+        <div class="center">{{ title }}</div>
+        <div class="right">
+          <v-ons-toolbar-button>
+            <v-ons-icon icon="ion-navicon, material: md-menu"></v-ons-icon>
+          </v-ons-toolbar-button>
+        </div>
+      </v-ons-toolbar>
+
+      <p style="text-align: center">
+        <v-ons-button @click="$ons.notification.alert('Hello World!')">
+          Click me!
+        </v-ons-button>
+      </p>
+    </v-ons-page>
+  </template>
+
+  <div id="app"></div>
+</body>
+</html>
+
+<!-- info
+
+## The `VOnsPage` component
+
+The `VOnsPage` component serves as the main view of a screen in an app. It covers the whole screen and is used as a container for the other components. When managing multiple views, all of them must be contained in `VOnsPage` components.
+
+```html
+<v-ons-page>
+  Content goes here
+</v-ons-page>
+```
+
+This component automatically spawns a `background` and a `content` elements. These can also be manually provided for higher customizability:
+
+```html
+<v-ons-page>
+  Toolbar here
+
+  <div class="background"></div>
+
+  <div class="content">
+    Scrollable content here
+  </div>
+
+  Fixed content here
+</v-ons-page>
+```
+
+Since `content` element is transparent by default, we can add custom colors to the `background` element. Notice that, if `content` element is provided, scrollable and fixed content must be manually separated as well.
+
+## Adding a toolbar
+
+The `VOnsToolbar` component displays a navigation bar on the top of a `VOnsPage` component. It is separated into three sections (left, center and right) in order to let the buttons and title be layouted a beautiful way.
+
+```html
+<v-ons-toolbar>
+  <div class="left">
+  </div>
+  <div class="center">
+  </div>
+  <div class="right">
+  </div>
+</v-ons-toolbar>
+```
+
+## The `$ons` object
+
+Onsen UI not only contains components, it also provides an object called `$ons` with a lot of useful functions attached to it.
+
+Enabling or disabling autostyling feature, setting a new global device back button handler, extending animations or getting device orientation events are just a bunch of examples.
+
+`$ons` object is exposed directly in Vue's prototype. Therefore, it can be accessed with `this.$ons` or `Vue.$ons`.
+
+## Showing a notification
+
+Just like in normal Onsen UI apps you can show dialogs using the `$ons.notification` methods:
+
+```javascript
+this.$ons.notification.alert('Hello world!');
+this.$ons.notification.confirm('Are you sure?', {...});
+this.$ons.notification.prompt('How are you?', {...});
+```
+-->


### PR DESCRIPTION
Splits tutorials up by component (e.g. checkbox, radio button and other input form elements are now in separate tutorials). There are some cases where the tutorials looked fine to me the way they were, so for those ones I made a copy of the original tutorial file which can be improved in the future if need be.

Could you look particularly at the code I wrote for the JS search input component please? I think this code could be vulnerable to an HTML injection, but I'm not 100% sure.