### PR TITLE
Only collapse script editor if there are zero lines of code

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -180,7 +180,7 @@ app.services.collapseEditors = function (html, code) {
   if (window.Split && app.config.autoHideHTMLPane !== false) {
     if (html.split(/\n/).length <= 1) {
       app.splits.editors.collapse(0);
-    } else if (code.split(/\n/).length <= 4) {
+    } else if (code.split(/\n/).length <= 1) {
       app.splits.editors.collapse(1);
     } else {
       app.splits.editors.setSizes([50, 50]);


### PR DESCRIPTION
Script editor was collapsing for tutorials with less than 4 lines of code e.g. JS search input. This changes it to only collapse if there are no lines of code.